### PR TITLE
feat: add MLP/FFN layer targeting for LoRA/LoKR training

### DIFF
--- a/acestep/training_v2/cli/args.py
+++ b/acestep/training_v2/cli/args.py
@@ -305,6 +305,7 @@ def _add_common_training_args(parser: argparse.ArgumentParser) -> None:
     g_lora.add_argument("--attention-type", type=str, default="both", choices=["self", "cross", "both"], help="Attention layers to target (default: both)")
     g_lora.add_argument("--self-target-modules", nargs="+", default=None, help="Projections for self-attention only (used when --attention-type=both)")
     g_lora.add_argument("--cross-target-modules", nargs="+", default=None, help="Projections for cross-attention only (used when --attention-type=both)")
+    g_lora.add_argument("--target-mlp", action=argparse.BooleanOptionalAction, default=False, help="Also target MLP/FFN layers (gate_proj, up_proj, down_proj)")
 
     # -- LoKR hyperparams ---------------------------------------------------
     g_lokr = parser.add_argument_group("LoKR (used when --adapter-type=lokr)")

--- a/acestep/training_v2/cli/config_builder.py
+++ b/acestep/training_v2/cli/config_builder.py
@@ -95,11 +95,13 @@ def build_configs(args: argparse.Namespace) -> Tuple[AdapterConfig, TrainingConf
 
     # -- Adapter config (LoRA or LoKR) --------------------------------------
     attention_type = getattr(args, "attention_type", "both")
+    target_mlp = getattr(args, "target_mlp", False)
     resolved_modules = resolve_target_modules(
         args.target_modules,
         attention_type,
         self_target_modules=getattr(args, "self_target_modules", None),
         cross_target_modules=getattr(args, "cross_target_modules", None),
+        target_mlp=target_mlp,
     )
 
     adapter_cfg: AdapterConfig
@@ -114,6 +116,7 @@ def build_configs(args: argparse.Namespace) -> Tuple[AdapterConfig, TrainingConf
             weight_decompose=getattr(args, "lokr_weight_decompose", False),
             target_modules=resolved_modules,
             attention_type=attention_type,
+            target_mlp=target_mlp,
         )
     else:
         adapter_cfg = LoRAConfigV2(
@@ -123,6 +126,7 @@ def build_configs(args: argparse.Namespace) -> Tuple[AdapterConfig, TrainingConf
             target_modules=resolved_modules,
             bias=args.bias,
             attention_type=attention_type,
+            target_mlp=target_mlp,
         )
 
     # -- Clamp DataLoader flags when num_workers <= 0 -----------------------

--- a/acestep/training_v2/configs.py
+++ b/acestep/training_v2/configs.py
@@ -37,9 +37,13 @@ class LoRAConfigV2(LoRAConfig):
     attention_type: str = "both"
     """Which attention layers to target: 'self', 'cross', or 'both'."""
 
+    target_mlp: bool = False
+    """Also target MLP/FFN layers (gate_proj, up_proj, down_proj)."""
+
     def to_dict(self) -> dict:
         base = super().to_dict()
         base["attention_type"] = self.attention_type
+        base["target_mlp"] = self.target_mlp
         return base
 
     # --- Data loading (declared here for compatibility with base packages
@@ -75,9 +79,13 @@ class LoKRConfigV2(LoKRConfig):
     attention_type: str = "both"
     """Which attention layers to target: 'self', 'cross', or 'both'."""
 
+    target_mlp: bool = False
+    """Also target MLP/FFN layers (gate_proj, up_proj, down_proj)."""
+
     def to_dict(self) -> dict:
         base = super().to_dict()
         base["attention_type"] = self.attention_type
+        base["target_mlp"] = self.target_mlp
         return base
 
 

--- a/acestep/training_v2/tui/screens/training_monitor.py
+++ b/acestep/training_v2/tui/screens/training_monitor.py
@@ -258,8 +258,10 @@ class TrainingMonitorScreen(Screen):
                 target_modules=resolve_target_modules(
                     target_mods_raw,
                     self.config.get("attention_type", "both"),
+                    target_mlp=self.config.get("target_mlp", False),
                 ),
                 attention_type=self.config.get("attention_type", "both"),
+                target_mlp=self.config.get("target_mlp", False),
             )
 
             # ---- build training config ------------------------------------

--- a/acestep/training_v2/ui/flows_train_steps.py
+++ b/acestep/training_v2/ui/flows_train_steps.py
@@ -139,6 +139,11 @@ def step_lora(a: dict) -> None:
 
     _ask_attention_type(a)
     _ask_projections(a)
+    a["target_mlp"] = ask_bool(
+        "Also target MLP/FFN layers (gate_proj, up_proj, down_proj)?",
+        default=a.get("target_mlp", False),
+        allow_back=True,
+    )
 
 
 def step_lokr(a: dict) -> None:
@@ -171,6 +176,11 @@ def step_lokr(a: dict) -> None:
 
     _ask_attention_type(a)
     _ask_projections(a)
+    a["target_mlp"] = ask_bool(
+        "Also target MLP/FFN layers (gate_proj, up_proj, down_proj)?",
+        default=a.get("target_mlp", False),
+        allow_back=True,
+    )
 
 
 def _default_shift(a: dict) -> float:

--- a/acestep/training_v2/ui/presets.py
+++ b/acestep/training_v2/ui/presets.py
@@ -110,6 +110,7 @@ PRESET_FIELDS = frozenset([
     "adapter_type",
     # LoRA settings
     "rank", "alpha", "dropout", "target_modules_str", "attention_type", "bias",
+    "self_target_modules_str", "cross_target_modules_str", "target_mlp",
     # LoKR settings
     "lokr_linear_dim", "lokr_linear_alpha", "lokr_factor",
     "lokr_decompose_both", "lokr_use_tucker", "lokr_use_scalar",


### PR DESCRIPTION
Add target_mlp boolean flag to enable targeting MLP layers (gate_proj, up_proj, down_proj) alongside attention projections during adapter training. Supported across CLI (--target-mlp), wizard, TUI, and preset export/import.

- Add target_mlp field to LoRAConfigV2 and LoKRConfigV2
- Extend resolve_target_modules() to append MLP modules when enabled
- Add --target-mlp CLI argument
- Wire through config_builder, wizard flows, and TUI training monitor
- Add target_mlp + split projection fields to PRESET_FIELDS
- Add 14 new unit tests covering wizard, CLI, and namespace paths