### PR TITLE
fix: macOS MPS fix for preprocessing and training loop

### DIFF
--- a/acestep/training_v2/_vendor/data_module.py
+++ b/acestep/training_v2/_vendor/data_module.py
@@ -213,10 +213,7 @@ class PreprocessedTensorDataset(Dataset):
             ("context_latents", context_latents),
         ]:
             if torch.isnan(_tens).any() or torch.isinf(_tens).any():
-                logger.warning(
-                    "[Side-Step] NaN/Inf in '%s' of %s -- replacing with zeros",
-                    _name, tensor_path,
-                )
+                logger.warning(f"[Side-Step] NaN/Inf in '{_name}' of {tensor_path} -- replacing with zeros")
                 _tens.nan_to_num_(nan=0.0, posinf=0.0, neginf=0.0)
 
         # Random chunking: slice a window from T-aligned tensors

--- a/acestep/training_v2/cli/train_fixed.py
+++ b/acestep/training_v2/cli/train_fixed.py
@@ -34,6 +34,8 @@ def _cleanup_gpu() -> None:
         import torch
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        elif hasattr(torch, 'mps') and torch.mps.is_available():
+            torch.mps.empty_cache()
     except ImportError:
         pass
 

--- a/acestep/training_v2/fisher/analysis.py
+++ b/acestep/training_v2/fisher/analysis.py
@@ -262,6 +262,8 @@ def run_fisher_analysis(
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
+    elif hasattr(torch, 'mps') and torch.mps.is_available():
+        torch.mps.empty_cache()
 
     # Enable gradient checkpointing -- critical for VRAM.
     # Try multiple approaches since the bare model (no PEFT/Fabric wrappers)

--- a/acestep/training_v2/fisher/spectral.py
+++ b/acestep/training_v2/fisher/spectral.py
@@ -54,6 +54,8 @@ def compute_spectral_complexity(
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+            elif hasattr(torch, 'mps') and torch.mps.is_available():
+                torch.mps.empty_cache()
 
         if (idx + 1) % 50 == 0 or idx == total - 1:
             logger.debug("Spectral analysis: %d/%d modules done", idx + 1, total)

--- a/acestep/training_v2/fixed_lora_module.py
+++ b/acestep/training_v2/fixed_lora_module.py
@@ -91,8 +91,6 @@ def _normalize_device_type(device: Any) -> str:
 def _select_compute_dtype(device_type: str) -> torch.dtype:
     if device_type in ("cuda", "xpu"):
         return torch.bfloat16
-    if device_type == "mps":
-        return torch.float16
     return torch.float32
 
 

--- a/acestep/training_v2/trainer_basic_loop.py
+++ b/acestep/training_v2/trainer_basic_loop.py
@@ -294,8 +294,11 @@ def run_basic_training_loop(
 
                 # Periodic CUDA cache cleanup to prevent intra-epoch
                 # memory fragmentation on consumer GPUs.
-                if torch.cuda.is_available() and global_step % cfg.log_every == 0:
-                    torch.cuda.empty_cache()
+                if global_step % cfg.log_every == 0:
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    elif hasattr(torch, 'mps') and torch.mps.is_available():
+                        torch.mps.empty_cache()
 
         # Flush remainder
         if accumulation_step > 0:
@@ -404,6 +407,8 @@ def run_basic_training_loop(
         # temporaries are also freed.
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        elif hasattr(torch, 'mps') and torch.mps.is_available():
+            torch.mps.empty_cache()
 
     # -- Sanity check: did we actually train? ----------------------------
     if global_step == 0:

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -314,6 +314,5 @@ class TestCudaFreeMb(unittest.TestCase):
             result = _cuda_free_mb(999)
             self.assertIsNone(result)
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/train.py
+++ b/train.py
@@ -95,6 +95,8 @@ def _cleanup_gpu() -> None:
         import torch
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        elif hasattr(torch, 'mps') and torch.mps.is_available():
+            torch.mps.empty_cache()
     except ImportError:
         pass
 


### PR DESCRIPTION
# WHAT IS THIS
Side-Step is awesome, but needed some minor tweaks to get running properly on macOS due to MPS backend. Preprocessor and training loop were basically NaN/Inf-ing out until now.

# TL;DR:
- Add additional torch mps backend conditionals where cuda is assumed ie: for `torch.mps.empty_cache()` 
- Remove incorrect dtype assumption of fp16 for mps (this was a mistake from an earlier ACE-Step-1.5 PR for MPS support)
- Add `_normalize_dtype()` helper to basically sanitise dtype, currently only checks if running on MPS and generally needs to be upcasted to fp32 for compatibility.