### PR TITLE
MPS (and XPU?) compatibility added again

### DIFF
--- a/sidestep_engine/analysis/audio_analysis.py
+++ b/sidestep_engine/analysis/audio_analysis.py
@@ -170,6 +170,12 @@ def _flush_vram() -> None:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
             torch.cuda.synchronize()
+        elif hasattr(torch, 'mps') and torch.mps.is_available():
+            torch.mps.empty_cache()
+            torch.mps.synchronize()
+        elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+            torch.xpu.empty_cache()
+            torch.xpu.synchronize()
     except ImportError:
         pass
 
@@ -182,8 +188,10 @@ def _resolve_device(device: str = "auto") -> str:
         import torch
         if torch.cuda.is_available():
             return "cuda"
-        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        if hasattr(torch, "mps") and torch.mps.is_available():
             return "mps"
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            return "xpu"
     except ImportError:
         pass
     return "cpu"

--- a/sidestep_engine/analysis/fisher/analysis.py
+++ b/sidestep_engine/analysis/fisher/analysis.py
@@ -266,9 +266,7 @@ def run_fisher_analysis(
         logger.warning("Could not offload non-decoder components: %s", exc)
 
     # Free GPU memory released by offloading
-    gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    _clear_cache(device)
 
     # Enable gradient checkpointing -- critical for VRAM.
     # Try multiple approaches since the bare model (no PEFT/Fabric wrappers)

--- a/sidestep_engine/analysis/fisher/engine.py
+++ b/sidestep_engine/analysis/fisher/engine.py
@@ -164,7 +164,7 @@ def _run_full(
                     data_proportion=data_proportion,
             )
             oom_count = 0
-        except torch.cuda.OutOfMemoryError:
+        except torch._C.OutOfMemoryError:
             oom_count += 1
             _clear_cache(device)
             logger.warning("OOM on batch %d (oom_count=%d)", batches_done, oom_count)
@@ -237,7 +237,7 @@ def _run_chunked(
                     data_proportion=data_proportion,
                 )
                 oom_count = 0
-            except torch.cuda.OutOfMemoryError:
+            except torch._C.OutOfMemoryError:
                 oom_count += 1
                 _clear_cache(device)
                 logger.warning(

--- a/sidestep_engine/analysis/fisher/spectral.py
+++ b/sidestep_engine/analysis/fisher/spectral.py
@@ -51,9 +51,14 @@ def compute_spectral_complexity(
             logger.warning("SVD failed for %s: %s -- skipping spectral data", name, exc)
             results[name] = -1  # sentinel for "unknown"
         finally:
+            
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+            elif hasattr(torch, 'mps') and torch.mps.is_available():
+                torch.mps.empty_cache()
+            elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+                torch.xpu.empty_cache()
 
         if (idx + 1) % 50 == 0 or idx == total - 1:
             logger.debug("Spectral analysis: %d/%d modules done", idx + 1, total)

--- a/sidestep_engine/cli/train_fixed.py
+++ b/sidestep_engine/cli/train_fixed.py
@@ -38,6 +38,11 @@ def _cleanup_gpu() -> None:
         import torch
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        elif hasattr(torch, 'mps') and torch.mps.is_available():
+            torch.mps.empty_cache()
+        elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+            torch.xpu.empty_cache()
+        
     except ImportError:
         pass
 
@@ -126,8 +131,8 @@ def run_fixed(args: argparse.Namespace) -> int:
         set_plain_mode(True)
 
     # -- GPU pre-flight --------------------------------------------------------
-    if not torch.cuda.is_available():
-        print("[FAIL] No CUDA GPU detected. Training requires a CUDA-capable GPU.", file=sys.stderr)
+    if not any([torch.cuda.is_available(), torch.mps.is_available(), torch.xpu.is_available()]):
+        print("[FAIL] No supported GPU detected. Training requires a capable GPU.", file=sys.stderr)
         return 1
 
     # -- Matmul precision (matches handler.initialize_service behaviour) ------

--- a/sidestep_engine/cli/train_fixed.py
+++ b/sidestep_engine/cli/train_fixed.py
@@ -131,7 +131,11 @@ def run_fixed(args: argparse.Namespace) -> int:
         set_plain_mode(True)
 
     # -- GPU pre-flight --------------------------------------------------------
-    if not any([torch.cuda.is_available(), torch.mps.is_available(), torch.xpu.is_available()]):
+    if not any([
+        torch.cuda.is_available(),
+        hasattr(torch, 'mps') and torch.mps.is_available(),
+        hasattr(torch, 'xpu') and torch.xpu.is_available()
+    ]):
         print("[FAIL] No supported GPU detected. Training requires a capable GPU.", file=sys.stderr)
         return 1
 

--- a/sidestep_engine/core/lora_module.py
+++ b/sidestep_engine/core/lora_module.py
@@ -97,21 +97,21 @@ def _normalize_device_type(device: Any) -> str:
 
 
 def _select_compute_dtype(device_type: str) -> torch.dtype:
-    if device_type in ("cuda", "xpu"):
+    if device_type in ("cuda", "xpu", "mps"):
         return torch.bfloat16
-    if device_type == "mps":
-        return torch.float16
+    # if device_type == "mps":
+    #     return torch.float16
     return torch.float32
 
 
 def _select_fabric_precision(device_type: str) -> str:
-    if device_type in ("cuda", "xpu"):
+    if device_type in ("cuda", "xpu", "mps"):
         return "bf16-mixed"
-    if device_type == "mps":
-        # "16-mixed" activates a GradScaler whose _unscale_grads_ crashes on
-        # MPS tensors.  Use "32-true" instead -- the training step's own
-        # torch.autocast still provides fp16 forward-pass benefits.
-        return "32-true"
+    # if device_type == "mps":
+    #     # "16-mixed" activates a GradScaler whose _unscale_grads_ crashes on
+    #     # MPS tensors.  Use "32-true" instead -- the training step's own
+    #     # torch.autocast still provides fp16 forward-pass benefits.
+    #     return "32-true"
     return "32-true"
 
 

--- a/sidestep_engine/core/trainer.py
+++ b/sidestep_engine/core/trainer.py
@@ -165,6 +165,10 @@ class FixedLoRATrainer:
             random.seed(cfg.seed)
             if torch.cuda.is_available():
                 torch.cuda.manual_seed_all(cfg.seed)
+            elif torch.mps.is_available():
+                torch.mps.manual_seed(cfg.seed)
+            elif torch.xpu.is_available():
+                torch.xpu.manual_seed_all(cfg.seed)
 
             # -- Build module -----------------------------------------------
             device = torch.device(cfg.device)
@@ -475,6 +479,10 @@ class FixedLoRATrainer:
                 yield TrainingUpdate(0, 0.0, f"[INFO] Offloaded {offloaded} model components to CPU (saves VRAM)", kind="info")
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
+                elif torch.mps.is_available():
+                    torch.mps.empty_cache()
+                elif torch.xpu.is_available():
+                    torch.xpu.is_available()
 
         # -- dtype / Fabric setup -------------------------------------------
         self.module.model = self.module.model.to(self.module.dtype)
@@ -841,8 +849,14 @@ class FixedLoRATrainer:
 
                     # Periodic CUDA cache cleanup to prevent intra-epoch
                     # memory fragmentation on consumer GPUs.
-                    if torch.cuda.is_available() and global_step % cfg.log_every == 0:
-                        torch.cuda.empty_cache()
+
+                    if global_step % cfg.log_every == 0:
+                        if torch.cuda.is_available():
+                            torch.cuda.empty_cache()
+                        elif torch.mps.is_available():
+                            torch.mps.empty_cache()
+                        elif torch.xpu.is_available():
+                            torch.xpu.is_available()
 
             # Flush remainder
             if accumulation_step > 0:
@@ -1027,6 +1041,10 @@ class FixedLoRATrainer:
             # temporaries are also freed.
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+            elif torch.mps.is_available():
+                torch.mps.empty_cache()
+            elif torch.xpu.is_available():
+                torch.xpu.is_available()
 
         # -- Sanity check: did we actually train? ----------------------------
         if global_step == 0:

--- a/sidestep_engine/core/trainer.py
+++ b/sidestep_engine/core/trainer.py
@@ -482,7 +482,7 @@ class FixedLoRATrainer:
                 elif torch.mps.is_available():
                     torch.mps.empty_cache()
                 elif torch.xpu.is_available():
-                    torch.xpu.is_available()
+                    torch.xpu.empty_cache()
 
         # -- dtype / Fabric setup -------------------------------------------
         self.module.model = self.module.model.to(self.module.dtype)

--- a/sidestep_engine/core/trainer.py
+++ b/sidestep_engine/core/trainer.py
@@ -856,7 +856,7 @@ class FixedLoRATrainer:
                         elif torch.mps.is_available():
                             torch.mps.empty_cache()
                         elif torch.xpu.is_available():
-                            torch.xpu.is_available()
+                            torch.xpu.empty_cache()
 
             # Flush remainder
             if accumulation_step > 0:
@@ -1044,7 +1044,7 @@ class FixedLoRATrainer:
             elif torch.mps.is_available():
                 torch.mps.empty_cache()
             elif torch.xpu.is_available():
-                torch.xpu.is_available()
+                torch.xpu.empty_cache()
 
         # -- Sanity check: did we actually train? ----------------------------
         if global_step == 0:

--- a/sidestep_engine/core/trainer_helpers.py
+++ b/sidestep_engine/core/trainer_helpers.py
@@ -226,8 +226,8 @@ def capture_rng_state(device: Any = None) -> Dict[str, Any]:
             rng["mps_device"] = idx
             rng["mps_rng"] = torch.mps.get_rng_state(dev)
         elif torch.xpu.is_available():
-            rng["xps_device"] = idx
-            rng["xps_rng"] = torch.mps.get_rng_state(dev)
+            rng["xpu_device"] = idx
+            rng["xpu_rng"] = torch.xpu.get_rng_state(dev)
     except Exception as exc:
         logger.debug("Could not capture RNG state: %s", exc)
     return rng

--- a/sidestep_engine/core/trainer_helpers.py
+++ b/sidestep_engine/core/trainer_helpers.py
@@ -216,14 +216,20 @@ def capture_rng_state(device: Any = None) -> Dict[str, Any]:
         "python": random.getstate(),
         "torch_cpu": torch.random.get_rng_state(),
     }
-    if torch.cuda.is_available() and device is not None:
-        try:
-            dev = torch.device(device)
-            idx = dev.index if dev.index is not None else 0
+    try:
+        dev = torch.device(device)
+        idx = dev.index if dev.index is not None else 0
+        if torch.cuda.is_available():
             rng["cuda_device"] = idx
             rng["cuda_rng"] = torch.cuda.get_rng_state(idx)
-        except Exception as exc:
-            logger.debug("Could not capture CUDA RNG state: %s", exc)
+        elif torch.mps.is_available():
+            rng["mps_device"] = idx
+            rng["mps_rng"] = torch.mps.get_rng_state(dev)
+        elif torch.xpu.is_available():
+            rng["xps_device"] = idx
+            rng["xps_rng"] = torch.mps.get_rng_state(dev)
+    except Exception as exc:
+        logger.debug("Could not capture RNG state: %s", exc)
     return rng
 
 
@@ -266,6 +272,52 @@ def restore_rng_state(rng_state: Dict[str, Any], current_device: Any = None) -> 
             logger.warning(
                 "[WARN] CUDA device changed (saved cuda:%d, current cuda:%d) "
                 "-- CUDA RNG not restored",
+                saved_idx, current_idx,
+            )
+    elif "mps_rng" in rng_state and torch.mps.is_available():
+        saved_idx = rng_state.get("mps_device", 0)
+        current_idx = 0
+        if current_device is not None:
+            dev = torch.device(current_device)
+            current_idx = dev.index if dev.index is not None else 0
+        if saved_idx == current_idx:
+            try:
+                mps_t = rng_state["mps_rng"]
+                if isinstance(mps_t, torch.Tensor):
+                    mps_t = mps_t.cpu()
+                    if mps_t.dtype != torch.uint8:
+                        mps_t = mps_t.to(torch.uint8)
+                torch.mps.set_rng_state(mps_t, current_idx)
+                restored.append("mps_rng")
+            except Exception as exc:
+                logger.warning("[WARN] Could not restore MPS RNG: %s", exc)
+        else:
+            logger.warning(
+                "[WARN] MPS device changed (saved mps:%d, current mps:%d) "
+                "-- MPS RNG not restored",
+                saved_idx, current_idx,
+            )
+    elif "xpu_rng" in rng_state and torch.xpu.is_available():
+        saved_idx = rng_state.get("xpu_device", 0)
+        current_idx = 0
+        if current_device is not None:
+            dev = torch.device(current_device)
+            current_idx = dev.index if dev.index is not None else 0
+        if saved_idx == current_idx:
+            try:
+                xpu_t = rng_state["xpu_rng"]
+                if isinstance(xpu_t, torch.Tensor):
+                    xpu_t = xpu_t.cpu()
+                    if xpu_t.dtype != torch.uint8:
+                        xpu_t = xpu_t.to(torch.uint8)
+                torch.xpu.set_rng_state(xpu_t, current_idx)
+                restored.append("xpu_rng")
+            except Exception as exc:
+                logger.warning("[WARN] Could not restore XPU RNG: %s", exc)
+        else:
+            logger.warning(
+                "[WARN] XPU device changed (saved xpu:%d, current xpu:%d) "
+                "-- XPU RNG not restored",
                 saved_idx, current_idx,
             )
     return restored

--- a/sidestep_engine/core/trainer_loop.py
+++ b/sidestep_engine/core/trainer_loop.py
@@ -572,8 +572,13 @@ def run_basic_training_loop(
 
                 # Periodic CUDA cache cleanup to prevent intra-epoch
                 # memory fragmentation on consumer GPUs.
-                if torch.cuda.is_available() and global_step % cfg.log_every == 0:
-                    torch.cuda.empty_cache()
+                if global_step % cfg.log_every == 0:
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    elif torch.mps.is_available():
+                        torch.mps.empty_cache()
+                    elif torch.xpu.is_available():
+                        torch.xpu.is_available()
 
         # Flush remainder
         if accumulation_step > 0:
@@ -731,6 +736,10 @@ def run_basic_training_loop(
         # temporaries are also freed.
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        elif torch.mps.is_available():
+            torch.mps.empty_cache()
+        elif torch.xpu.is_available():
+            torch.xpu.is_available()
 
     # -- Sanity check: did we actually train? ----------------------------
     if global_step == 0:

--- a/sidestep_engine/core/trainer_loop.py
+++ b/sidestep_engine/core/trainer_loop.py
@@ -578,7 +578,7 @@ def run_basic_training_loop(
                     elif torch.mps.is_available():
                         torch.mps.empty_cache()
                     elif torch.xpu.is_available():
-                        torch.xpu.is_available()
+                        torch.xpu.empty_cache()
 
         # Flush remainder
         if accumulation_step > 0:

--- a/sidestep_engine/core/trainer_loop.py
+++ b/sidestep_engine/core/trainer_loop.py
@@ -736,10 +736,10 @@ def run_basic_training_loop(
         # temporaries are also freed.
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
-        elif torch.mps.is_available():
+        elif hasattr(torch, 'mps') and torch.mps.is_available():
             torch.mps.empty_cache()
-        elif torch.xpu.is_available():
-            torch.xpu.is_available()
+        elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+            torch.xpu.empty_cache()
 
     # -- Sanity check: did we actually train? ----------------------------
     if global_step == 0:

--- a/sidestep_engine/data/caption_provider_local.py
+++ b/sidestep_engine/data/caption_provider_local.py
@@ -358,9 +358,9 @@ def _load_model(tier: str, *, allow_cpu_offload: bool = False) -> None:
 
     if torch.cuda.is_available():
         load_kwargs["device_map"] = "auto" if allow_cpu_offload else {"": "cuda:0"}
-    elif torch.mps.is_available():
+    elif hasattr(torch, 'mps') and torch.mps.is_available():
         load_kwargs["device_map"] = "mps"
-    elif torch.xpu.is_available():
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
         load_kwargs["device_map"] = "xpu"
     else:
         load_kwargs["device_map"] = "cpu"

--- a/sidestep_engine/data/caption_provider_local.py
+++ b/sidestep_engine/data/caption_provider_local.py
@@ -71,6 +71,10 @@ def _clear_cuda_memory() -> None:
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
+    elif torch.mps.is_available():
+        torch.mps.empty_cache()
+    elif torch.xpu.is_available():
+        torch.xpu.is_available()
 
 
 def _resolve_local_generation_settings(
@@ -139,7 +143,7 @@ def _generation_attempts(
 
 
 def _is_oom_error(exc: BaseException) -> bool:
-    if isinstance(exc, torch.cuda.OutOfMemoryError):
+    if isinstance(exc, torch._C.OutOfMemoryError):
         return True
     return "out of memory" in str(exc).lower()
 
@@ -268,6 +272,9 @@ def _pick_dtype() -> torch.dtype:
     """Pick bf16 on Ampere+ GPUs, fall back to fp16."""
     if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
         return torch.bfloat16
+    elif torch.mps.is_available():
+        return torch.bfloat16
+        #return torch.float32
     return torch.float16
 
 
@@ -351,6 +358,10 @@ def _load_model(tier: str, *, allow_cpu_offload: bool = False) -> None:
 
     if torch.cuda.is_available():
         load_kwargs["device_map"] = "auto" if allow_cpu_offload else {"": "cuda:0"}
+    elif torch.mps.is_available():
+        load_kwargs["device_map"] = "mps"
+    elif torch.xpu.is_available():
+        load_kwargs["device_map"] = "xpu"
     else:
         load_kwargs["device_map"] = "cpu"
 
@@ -534,7 +545,7 @@ def generate_caption(
                 raise last_error
             return None
 
-        last_oom: Optional[torch.cuda.OutOfMemoryError] = None
+        last_oom: Optional[torch._C.OutOfMemoryError] = None
         for attempt in attempts:
             try:
                 generate_started = time.perf_counter()
@@ -553,7 +564,7 @@ def generate_caption(
                 with torch.inference_mode():
                     text_ids = _model.generate(**gen_kwargs)
                 break
-            except torch.cuda.OutOfMemoryError as exc:
+            except torch._C.OutOfMemoryError as exc:
                 last_oom = exc
                 text_ids = None
                 _clear_cuda_memory()
@@ -596,7 +607,7 @@ def generate_caption(
 
         logger.warning("Local model returned empty for: %s - %s", artist, title)
         return None
-    except torch.cuda.OutOfMemoryError as exc:
+    except torch._C.OutOfMemoryError as exc:
         raise LocalCaptionOOMError(
             "Local captioning ran out of GPU memory. Enable CPU offload or switch tiers."
         ) from exc

--- a/sidestep_engine/data/caption_provider_local.py
+++ b/sidestep_engine/data/caption_provider_local.py
@@ -74,7 +74,7 @@ def _clear_cuda_memory() -> None:
     elif torch.mps.is_available():
         torch.mps.empty_cache()
     elif torch.xpu.is_available():
-        torch.xpu.is_available()
+        torch.xpu.empty_cache()
 
 
 def _resolve_local_generation_settings(

--- a/sidestep_engine/data/preprocess.py
+++ b/sidestep_engine/data/preprocess.py
@@ -464,8 +464,6 @@ def _pass1_light(
 
             except Exception as exc:
                 failed += 1
-                print(exc)
-                import pdb; pdb.set_trace()
                 logger.error("[Side-Step] Pass 1 FAIL %s: %s", af.name, exc)
 
     finally:

--- a/sidestep_engine/data/preprocess.py
+++ b/sidestep_engine/data/preprocess.py
@@ -452,6 +452,10 @@ def _pass1_light(
                 del lyric_hs, lyric_mask
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
+                elif torch.mps.is_available():
+                    torch.mps.empty_cache()
+                elif torch.xpu.is_available():
+                    torch.xpu.is_available()
 
                 intermediates.append(tmp_path)
                 logger.debug("[Side-Step] Pass 1 OK: %s", af.name)
@@ -460,6 +464,8 @@ def _pass1_light(
 
             except Exception as exc:
                 failed += 1
+                print(exc)
+                import pdb; pdb.set_trace()
                 logger.error("[Side-Step] Pass 1 FAIL %s: %s", af.name, exc)
 
     finally:
@@ -592,6 +598,10 @@ def _pass2_heavy(
                 del encoder_hs, encoder_mask, context_latents, data
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
+                elif torch.mps.is_available():
+                    torch.mps.empty_cache()
+                elif torch.xpu.is_available():
+                    torch.xpu.is_available()
 
                 # Remove intermediate
                 tmp_path.unlink(missing_ok=True)

--- a/sidestep_engine/data/preprocess.py
+++ b/sidestep_engine/data/preprocess.py
@@ -598,10 +598,10 @@ def _pass2_heavy(
                 del encoder_hs, encoder_mask, context_latents, data
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
-                elif torch.mps.is_available():
+                elif hasattr(torch, 'mps') and torch.mps.is_available():
                     torch.mps.empty_cache()
-                elif torch.xpu.is_available():
-                    torch.xpu.is_available()
+                elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+                    torch.xpu.empty_cache()
 
                 # Remove intermediate
                 tmp_path.unlink(missing_ok=True)

--- a/sidestep_engine/data/preprocess.py
+++ b/sidestep_engine/data/preprocess.py
@@ -452,10 +452,10 @@ def _pass1_light(
                 del lyric_hs, lyric_mask
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
-                elif torch.mps.is_available():
+                elif hasattr(torch, 'mps') and torch.mps.is_available():
                     torch.mps.empty_cache()
-                elif torch.xpu.is_available():
-                    torch.xpu.is_available()
+                elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+                    torch.xpu.empty_cache()
 
                 intermediates.append(tmp_path)
                 logger.debug("[Side-Step] Pass 1 OK: %s", af.name)

--- a/sidestep_engine/data/preprocess_vae.py
+++ b/sidestep_engine/data/preprocess_vae.py
@@ -57,15 +57,19 @@ def tiled_vae_encode(
                 gpu_mem_gb = props.total_mem / (1024 ** 3)
                 chunk_size = TARGET_SR * 15 if gpu_mem_gb <= 8 else TARGET_SR * 30
             elif torch.mps.is_available():
-                gpu_mem_gb = torch.mps.driver_allocated_memory() / (1024 ** 3)
+                gpu_mem_gb = torch.mps.recommended_max_memory() / (1024 ** 3)
                 chunk_size = TARGET_SR * 15 if gpu_mem_gb <= 8 else TARGET_SR * 30
             elif torch.xpu.is_available():
                 props = torch.xpu.get_device_properties(vae_device)
-                gpu_mem_gb = props.total_mem / (1024 ** 3)
+                gpu_mem_gb = props.total_memory / (1024 ** 3)
                 chunk_size = TARGET_SR * 15 if gpu_mem_gb <= 8 else TARGET_SR * 30
+            else:
+                chunk_size = TARGET_SR * 30
             
-        except Exception:
-             pass
+        except Exception as exc:
+            import traceback
+            traceback.print_exception(exc)
+            chunk_size = TARGET_SR * 30
 
     B, C, S = audio.shape
 

--- a/sidestep_engine/data/preprocess_vae.py
+++ b/sidestep_engine/data/preprocess_vae.py
@@ -51,13 +51,21 @@ def tiled_vae_encode(
     # Auto-select chunk size based on GPU VRAM
     if chunk_size is None:
         gpu_mem_gb = 0.0
-        if torch.cuda.is_available():
-            try:
+        try:
+            if torch.cuda.is_available():
                 props = torch.cuda.get_device_properties(vae_device)
                 gpu_mem_gb = props.total_mem / (1024 ** 3)
-            except Exception:
-                pass
-        chunk_size = TARGET_SR * 15 if gpu_mem_gb <= 8 else TARGET_SR * 30
+                chunk_size = TARGET_SR * 15 if gpu_mem_gb <= 8 else TARGET_SR * 30
+            elif torch.mps.is_available():
+                gpu_mem_gb = torch.mps.driver_allocated_memory() / (1024 ** 3)
+                chunk_size = TARGET_SR * 15 if gpu_mem_gb <= 8 else TARGET_SR * 30
+            elif torch.xpu.is_available():
+                props = torch.xpu.get_device_properties(vae_device)
+                gpu_mem_gb = props.total_mem / (1024 ** 3)
+                chunk_size = TARGET_SR * 15 if gpu_mem_gb <= 8 else TARGET_SR * 30
+            
+        except Exception:
+             pass
 
     B, C, S = audio.shape
 

--- a/sidestep_engine/gui/task_manager.py
+++ b/sidestep_engine/gui/task_manager.py
@@ -82,10 +82,10 @@ def _remember_history_root_for_output(config: Dict[str, Any]) -> None:
 
 
 _OOM_PATTERNS = (
-    "CUDA out of memory",
+    "GPU out of memory",
     "torch.OutOfMemoryError",
-    "torch.cuda.OutOfMemoryError",
-    "RuntimeError: CUDA error: out of memory",
+    "torch._C.OutOfMemoryError",
+    "RuntimeError: GPU error: out of memory",
 )
 
 _EXIT_CODE_LABELS = {

--- a/sidestep_engine/models/gpu_utils.py
+++ b/sidestep_engine/models/gpu_utils.py
@@ -86,8 +86,8 @@ def detect_gpu(requested_device: str = "auto", requested_precision: str = "auto"
         vram_free = _cuda_free_mb(idx)
     elif device_type == "mps":
         name = "Apple MPS"
-        vram_total = torch.mps.driver_allocated_memory() / (1024 ** 2) # TODO
-        vram_free = torch.mps.current_allocated_memory() / (1024 ** 2) # TODO
+        vram_total = torch.mps.recommended_max_memory() / (1024 ** 2)
+        vram_free = (torch.mps.recommended_max_memory() - torch.mps.current_allocated_memory()) / (1024 ** 2)
     elif device_type == "xpu":
         idx = 0
         if ":" in device_str:

--- a/sidestep_engine/models/gpu_utils.py
+++ b/sidestep_engine/models/gpu_utils.py
@@ -57,7 +57,7 @@ def detect_gpu(requested_device: str = "auto", requested_precision: str = "auto"
         if torch.cuda.is_available():
             device_str = f"cuda:{_best_cuda_device()}"
             device_type = "cuda"
-        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        elif hasattr(torch, "mps") and torch.mps.is_available():
             device_str = "mps"
             device_type = "mps"
         elif hasattr(torch, "xpu") and torch.xpu.is_available():
@@ -86,6 +86,8 @@ def detect_gpu(requested_device: str = "auto", requested_precision: str = "auto"
         vram_free = _cuda_free_mb(idx)
     elif device_type == "mps":
         name = "Apple MPS"
+        vram_total = torch.mps.driver_allocated_memory() / (1024 ** 2) # TODO
+        vram_free = torch.mps.current_allocated_memory() / (1024 ** 2) # TODO
     elif device_type == "xpu":
         idx = 0
         if ":" in device_str:
@@ -99,10 +101,8 @@ def detect_gpu(requested_device: str = "auto", requested_precision: str = "auto"
 
     # Resolve precision
     if requested_precision == "auto":
-        if device_type in ("cuda", "xpu"):
+        if device_type in ("cuda", "xpu", "mps"):
             precision = "bf16"
-        elif device_type == "mps":
-            precision = "fp16"
         else:
             precision = "fp32"
     else:
@@ -121,11 +121,17 @@ def detect_gpu(requested_device: str = "auto", requested_precision: str = "auto"
 def _cuda_free_mb(idx: int = 0) -> Optional[float]:
     """Return free CUDA memory in MiB, or None on failure."""
     try:
-        torch.cuda.synchronize(idx)
-        free, _total = torch.cuda.mem_get_info(idx)
-        return free / (1024 ** 2)
+        if torch.cuda.is_available():
+            torch.cuda.synchronize(idx)
+            free, _total = torch.cuda.mem_get_info(idx)
+            return free / (1024 ** 2)
+        elif torch.mps.is_available():
+            torch.mps.synchronize()
+        elif torch.xpu.is_available():
+            torch.xpu.synchronize(idx)
     except (RuntimeError, AssertionError):
-        return None
+        pass
+    return None
 
 
 def get_available_vram_mb(device: str = "auto") -> Optional[float]:

--- a/sidestep_engine/models/loader.py
+++ b/sidestep_engine/models/loader.py
@@ -344,10 +344,10 @@ def cleanup_preprocessing_models(models: Dict[str, Any]) -> None:
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
-    elif torch.mps.is_available():
+    elif hasattr(torch, 'mps') and torch.mps.is_available():
         torch.mps.empty_cache()
-    elif torch.xpu.is_available():
-        torch.xpu.is_available()
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+        torch.xpu.empty_cache()
     logger.info("[OK] Preprocessing models cleaned up")
 
 

--- a/sidestep_engine/models/loader.py
+++ b/sidestep_engine/models/loader.py
@@ -509,8 +509,8 @@ def unload_models(*models: Any) -> None:
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
-    elif torch.mps.is_available():
+    elif hasattr(torch, 'mps') and torch.mps.is_available():
         torch.mps.empty_cache()
-    elif torch.xpu.is_available():
-        torch.xpu.is_available()
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+        torch.xpu.empty_cache()
     logger.info("[OK] Models unloaded and GPU cache cleared")

--- a/sidestep_engine/models/loader.py
+++ b/sidestep_engine/models/loader.py
@@ -344,6 +344,10 @@ def cleanup_preprocessing_models(models: Dict[str, Any]) -> None:
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
+    elif torch.mps.is_available():
+        torch.mps.empty_cache()
+    elif torch.xpu.is_available():
+        torch.xpu.is_available()
     logger.info("[OK] Preprocessing models cleaned up")
 
 
@@ -505,4 +509,8 @@ def unload_models(*models: Any) -> None:
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
+    elif torch.mps.is_available():
+        torch.mps.empty_cache()
+    elif torch.xpu.is_available():
+        torch.xpu.is_available()
     logger.info("[OK] Models unloaded and GPU cache cleared")

--- a/sidestep_engine/training_defaults.py
+++ b/sidestep_engine/training_defaults.py
@@ -20,6 +20,7 @@ config dicts produced by the frontend.
 
 from __future__ import annotations
 
+import torch
 import os
 import sys
 
@@ -42,7 +43,7 @@ DEFAULT_DATASET_REPEATS: int = 1
 # Optimizer / scheduler
 # ---------------------------------------------------------------------------
 
-DEFAULT_OPTIMIZER_TYPE: str = "adamw8bit"
+DEFAULT_OPTIMIZER_TYPE: str = "adamw8bit" if torch.cuda.is_available() else "adamw"
 DEFAULT_SCHEDULER_TYPE: str = "cosine"
 DEFAULT_SCHEDULER_FORMULA: str = ""
 

--- a/sidestep_engine/ui/gpu_monitor.py
+++ b/sidestep_engine/ui/gpu_monitor.py
@@ -68,7 +68,7 @@ class GPUMonitor:
         self._device_type = device.split(":")[0]
         self._interval = interval
         self._last: Optional[VRAMSnapshot] = None
-        self._available = self._device_type == "cuda"
+        self._available = self._device_type in ["cuda", "mps", "xpu"]
         self._name: str = ""
         self._total_mb: float = 0.0
         self._init_static()
@@ -83,9 +83,9 @@ class GPUMonitor:
             import torch
 
             idx = self._cuda_idx()
-            self._name = torch.cuda.get_device_name(idx)
+            self._name = torch.cuda.get_device_name(idx) if torch.cuda.is_available() else "Other GPU"
             self._total_mb = (
-                torch.cuda.get_device_properties(idx).total_memory / (1024 ** 2)
+                torch.cuda.get_device_properties(idx).total_memory / (1024 ** 2) if torch.cuda.is_available() else 0 # TODO
             )
         except Exception:
             self._available = False
@@ -118,11 +118,24 @@ class GPUMonitor:
             import torch
 
             idx = self._cuda_idx()
-            torch.cuda.synchronize(idx)
-            reserved = torch.cuda.memory_reserved(idx) / (1024 ** 2)
-            free_bytes, total_bytes = torch.cuda.mem_get_info(idx)
-            global_free_mb = free_bytes / (1024 ** 2)
-            global_used_mb = max(0.0, (total_bytes - free_bytes) / (1024 ** 2))
+            reserved = 0
+            free_bytes, total_bytes = 0, 0
+            global_free_mb = 0
+            global_used_mb = 0
+
+            if torch.cuda.is_available():
+                torch.cuda.synchronize(idx)
+                reserved = torch.cuda.memory_reserved(idx) / (1024 ** 2)
+                free_bytes, total_bytes = torch.cuda.mem_get_info(idx)
+                global_free_mb = free_bytes / (1024 ** 2)
+                global_used_mb = max(0.0, (total_bytes - free_bytes) / (1024 ** 2))
+            elif torch.mps.is_available():
+                torch.mps.synchronize()
+                # TODO
+            elif torch.xpu.is_available():
+                torch.xpu.synchronize(idx)
+                # TODO
+            
             snap = VRAMSnapshot(
                 used_mb=reserved,
                 total_mb=self._total_mb,
@@ -147,6 +160,11 @@ class GPUMonitor:
             return 0.0
         try:
             import torch
-            return torch.cuda.max_memory_allocated(self._cuda_idx()) / (1024 ** 2)
+            if torch.cuda.is_available():
+                return torch.cuda.max_memory_allocated(self._cuda_idx()) / (1024 ** 2)
+            elif torch.mps.is_available():
+                return torch.mps.driver_allocated_memory() / (1024 ** 2) # TODO
+            elif torch.xpu.is_available():
+                return torch.xpu.max_memory_allocated(self,self._cuda_idx()) / (1024 ** 2)
         except Exception:
             return 0.0

--- a/sidestep_engine/ui/gpu_monitor.py
+++ b/sidestep_engine/ui/gpu_monitor.py
@@ -165,6 +165,6 @@ class GPUMonitor:
             elif torch.mps.is_available():
                 return torch.mps.driver_allocated_memory() / (1024 ** 2) # TODO
             elif torch.xpu.is_available():
-                return torch.xpu.max_memory_allocated(self,self._cuda_idx()) / (1024 ** 2)
+                return torch.xpu.max_memory_allocated(self._cuda_idx()) / (1024 ** 2)
         except Exception:
             return 0.0

--- a/train.py
+++ b/train.py
@@ -140,6 +140,10 @@ def _cleanup_gpu() -> None:
         import torch
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        elif hasattr(torch, 'mps') and torch.mps.is_available():
+            torch.mps.empty_cache()
+        elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+            torch.xpu.empty_cache()
     except ImportError:
         pass
 


### PR DESCRIPTION
# HUH?
Since post-0.9, the MPS compatibility changes from PR #8 got nuked for whatever reason, and the vibe-coded re-attempt on commit https://github.com/koda-dernet/Side-Step/commit/ee4b5ecf3436abdda9a6cb24383a9c2a02942298 was hot garbage and non-functional, I decided to do it properly again.

# OK SO WHAT?
- Fixed the training and preprocessing loop (again) to work with MPS.
- Also decided to add XPU while I was there since PyTorch already has enough of an interface to manage this
- adamw8bit only available by default for CUDA. Must use adamw for MPS else it won't work.
- bfloat16 seems to also work. (Not sure with older PyTorch/macOS, need more testers?)

# CAVEAT
- Preprocessing, must ensure end user has installed ffmpeg via brew. `ie: brew install ffmpeg` else the torchcodec stuff will fail.
- Preprocessing++ spectral steps don't work due to cross_attn opcodes not implemented for PyTorch MPS. See log:

```
026-03-28 17:19:00 [INFO] sidestep_engine.models.loader: Using sdpa fallback (training is valid; memory/perf may be lower than FA2)
2026-03-28 17:19:01 [INFO] sidestep_engine.models.loader: [OK] Model on mps (torch.bfloat16), all params frozen
2026-03-28 17:19:01 [INFO] sidestep_engine.analysis.fisher.analysis: Gradient checkpointing enabled for Fisher analysis
2026-03-28 17:19:01 [INFO] sidestep_engine.analysis.fisher.analysis: Module discovery: 264 modules, 264 params mapped
2026-03-28 17:19:01 [INFO] sidestep_engine.analysis.fisher.analysis: Using chunked mode (3 passes, 4567 MB free VRAM)
2026-03-28 17:19:01.179 | INFO     | sidestep_engine.vendor.data_module:__init__:195 - RAM cache enabled: %d samples loaded (%.1f MB)
2026-03-28 17:19:01.179 | INFO     | sidestep_engine.vendor.data_module:__init__:231 - PreprocessedTensorDataset: 4 samples from /Users/djtubig-malicex/Downloads/gitrepos/ACE-Step-1.5/Side-Step/preprocessed_tensors/japangamemusic-test-mac
2026-03-28 17:19:01 [INFO] sidestep_engine.analysis.fisher.analysis: Fisher run 1/2
2026-03-28 17:19:01 [INFO] sidestep_engine.analysis.fisher.engine: Chunked pass 1/3 (self_attn, 96 modules)
  fisher/self_attn (1/12)
  fisher/self_attn (2/12)
  fisher/self_attn (3/12)
  fisher/self_attn (4/12)
2026-03-28 17:19:13 [INFO] sidestep_engine.analysis.fisher.engine: Chunked pass 2/3 (cross_attn, 96 modules)
  fisher/cross_attn (5/12)
  fisher/cross_attn (6/12)
  fisher/cross_attn (7/12)
  fisher/cross_attn (8/12)
2026-03-28 17:19:26 [INFO] sidestep_engine.analysis.fisher.engine: Chunked pass 3/3 (mlp, 72 modules)
  fisher/mlp (9/12)
  fisher/mlp (10/12)
  fisher/mlp (11/12)
  fisher/mlp (12/12)
2026-03-28 17:19:39 [INFO] sidestep_engine.analysis.fisher.analysis: Fisher run 2/2
2026-03-28 17:19:39 [INFO] sidestep_engine.analysis.fisher.engine: Chunked pass 1/3 (self_attn, 96 modules)
  fisher/self_attn (1/12)
  fisher/self_attn (2/12)
  fisher/self_attn (3/12)
  fisher/self_attn (4/12)
2026-03-28 17:19:52 [INFO] sidestep_engine.analysis.fisher.engine: Chunked pass 2/3 (cross_attn, 96 modules)
  fisher/cross_attn (5/12)
  fisher/cross_attn (6/12)
  fisher/cross_attn (7/12)
  fisher/cross_attn (8/12)
2026-03-28 17:20:04 [INFO] sidestep_engine.analysis.fisher.engine: Chunked pass 3/3 (mlp, 72 modules)
  fisher/mlp (9/12)
  fisher/mlp (10/12)
  fisher/mlp (11/12)
  fisher/mlp (12/12)
2026-03-28 17:20:18 [INFO] sidestep_engine.analysis.fisher.analysis: Running spectral analysis on 264 modules
2026-03-28 17:20:18 [WARNING] sidestep_engine.analysis.fisher.spectral: SVD failed for decoder.layers.0.cross_attn.k_proj: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS. -- skipping spectral data
2026-03-28 17:20:18 [WARNING] sidestep_engine.analysis.fisher.spectral: SVD failed for decoder.layers.0.cross_attn.o_proj: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS. -- skipping spectral data
2026-03-28 17:20:18 [WARNING] sidestep_engine.analysis.fisher.spectral: SVD failed for decoder.layers.0.cross_attn.q_proj: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS. -- skipping spectral data
2026-03-28 17:20:18 [WARNING] sidestep_engine.analysis.fisher.spectral: SVD failed for decoder.layers.0.cross_attn.v_proj: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS. -- skipping spectral data
2026-03-28 17:20:18 [WARNING] sidestep_engine.analysis.fisher.spectral: SVD failed for decoder.layers.0.mlp.down_proj: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS. -- skipping spectral data

... snip several hunderd dupes ...

2026-03-28 17:20:39 [WARNING] sidestep_engine.analysis.fisher.spectral: SVD failed for decoder.layers.9.self_attn.q_proj: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS. -- skipping spectral data
2026-03-28 17:20:39 [WARNING] sidestep_engine.analysis.fisher.spectral: SVD failed for decoder.layers.9.self_attn.v_proj: The operator 'aten::_linalg_svd.U' is not currently implemented for the MPS device. If you want this op to be considered for addition please comment on https://github.com/pytorch/pytorch/issues/141287 and mention use-case, that resulted in missing op as well as commit hash 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS. -- skipping spectral data

  Side-Step Fisher + Spectral Analysis
  ───────────────────────────────────────────────────────
  Model: acestep-v15-base | Batches: 8 (2 runs) | Modules analyzed: 264
  Timestep focus: balanced -- full timestep distribution
  Sample coverage: 4.0/4 per run (avg 100.0%)

  Module Selection: 145 included, 119 excluded
    Self-attention:  73 modules
    Cross-attention: 14 modules
    MLP:             58 modules

  Rank Distribution (base rank = 64):
    rank   40:  27 modules
    rank   48:  20 modules
    rank   56:  15 modules
    rank   64:  23 modules  ← base
    rank   72:  10 modules
    rank   80:   3 modules
    rank   88:   5 modules
    rank   96:   2 modules
    rank  104:   2 modules
    rank  112:   3 modules
    rank  120:   1 modules
    rank  128:  34 modules (max)

  Top 5 (highest rank assigned):
    layers.0.self_attn.v_proj                         F=5.29e-08  ER=  ?  → rank 128
    layers.9.self_attn.v_proj                         F=3.80e-09  ER=  ?  → rank 128
    layers.3.self_attn.v_proj                         F=3.68e-09  ER=  ?  → rank 128
    layers.7.self_attn.v_proj                         F=3.58e-09  ER=  ?  → rank 128
    layers.5.self_attn.v_proj                         F=3.36e-09  ER=  ?  → rank 128

  Low-Confidence Modules (cross-run std > 50% of mean):
    ⚠ decoder.layers.3.cross_attn.q_proj  F=2.36e-11±2.19e-11
    ⚠ decoder.layers.12.cross_attn.k_proj  F=4.62e-11±4.17e-11
    ⚠ decoder.layers.15.cross_attn.k_proj  F=6.74e-12±5.61e-12
  ───────────────────────────────────────────────────────

2026-03-28 17:20:39 [INFO] sidestep_engine.analysis.fisher.io: Fisher map saved to /Users/djtubig-malicex/Downloads/gitrepos/ACE-Step-1.5/Side-Step/preprocessed_tensors/japangamemusic-test-mac/fisher_map.json
2026-03-28 17:20:39 [INFO] sidestep_engine.models.loader: [OK] Models unloaded and GPU cache cleared
  Preprocessing++ complete — adaptive ranks saved.
```

<img width="2316" height="1300" alt="image" src="https://github.com/user-attachments/assets/666ab489-ecf6-4258-aab0-1a38a4f05ad9" />


Tested w/ macOS Tahoe 26.3.1, Apple M3 Ultra 256GB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Apple MPS and Intel XPU accelerators alongside CUDA.

* **Bug Fixes**
  * Made out-of-memory detection and handling accelerator-agnostic for consistent recovery.

* **Improvements**
  * Unified and expanded accelerator-aware memory/cache cleanup across workflows.
  * Device-aware RNG capture/restore, seeding, and precision selection.
  * Adaptive optimizer defaults and broader GPU monitoring for non-CUDA backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->