### PR TITLE
fix: auto fp16 fallback for pre-Ampere GPUs (T4 / Turing)

### DIFF
--- a/sidestep_engine/core/lora_module.py
+++ b/sidestep_engine/core/lora_module.py
@@ -96,8 +96,31 @@ def _normalize_device_type(device: Any) -> str:
     return str(device)
 
 
+def _cuda_supports_bf16() -> bool:
+    """Return True only when the active CUDA device natively supports bf16.
+
+    Ampere (sm_80+) supports bf16 in hardware.  Older GPUs like T4 (sm_75)
+    execute bf16 ops emulated in software via fp32, which causes overflow /
+    NaN losses during training.  We probe the device property directly rather
+    than hard-coding a whitelist.
+    """
+    if not torch.cuda.is_available():
+        return False
+    try:
+        # is_bf16_supported() was added in PyTorch 1.12
+        return torch.cuda.is_bf16_supported()
+    except AttributeError:
+        # Older PyTorch -- fall back to capability check
+        major, _ = torch.cuda.get_device_capability()
+        return major >= 8  # Ampere and newer
+
+
 def _select_compute_dtype(device_type: str) -> torch.dtype:
     if device_type in ("cuda", "xpu"):
+        # Use bf16 only when the GPU natively supports it (Ampere+).
+        # T4 (sm_75) and earlier fall back to fp16.
+        if device_type == "cuda" and not _cuda_supports_bf16():
+            return torch.float16
         return torch.bfloat16
     if device_type == "mps":
         return torch.float16
@@ -106,6 +129,9 @@ def _select_compute_dtype(device_type: str) -> torch.dtype:
 
 def _select_fabric_precision(device_type: str) -> str:
     if device_type in ("cuda", "xpu"):
+        # Mirror compute dtype: fp16 AMP on devices without native bf16.
+        if device_type == "cuda" and not _cuda_supports_bf16():
+            return "16-mixed"
         return "bf16-mixed"
     if device_type == "mps":
         # "16-mixed" activates a GradScaler whose _unscale_grads_ crashes on

--- a/sidestep_engine/core/trainer.py
+++ b/sidestep_engine/core/trainer.py
@@ -524,7 +524,15 @@ class FixedLoRATrainer:
                     torch.cuda.empty_cache()
 
         # -- dtype / Fabric setup -------------------------------------------
-        self.module.model = self.module.model.to(self.module.dtype)
+        # Cast ONLY the frozen base model weights to the compute dtype.
+        # Adapter (LoRA/LoKR) parameters MUST remain in fp32 so the AMP
+        # GradScaler can unscale their gradients correctly.
+        # Rule: GradScaler requires trainable params in fp32; only the
+        # forward pass computation is done in fp16 via autocast.
+        _adapter_ids = {id(p) for p in self.module.model.parameters() if p.requires_grad}
+        for p in self.module.model.parameters():
+            if id(p) not in _adapter_ids:
+                p.data = p.data.to(self.module.dtype)
         self.module.model.decoder, optimizer = self.fabric.setup(self.module.model.decoder, optimizer)
 
         # -- Resume ---------------------------------------------------------


### PR DESCRIPTION
## Problem

Side-Step hardcodes `bf16` precision for all CUDA training. NVIDIA T4 and older GPUs (compute capability < 8.0) do not have native bf16 hardware support, causing two cascading failures:

1. **NaN losses from step 1** — bf16 operations overflow on T4 (emulated through fp32 internally).
2. **`ValueError: Attempting to unscale FP16 gradients`** — `trainer.py` calls `model.to(torch.float16)` which casts all parameters including LoRA/LoKR adapter weights to fp16 storage. The AMP GradScaler requires trainable params to stay in fp32.

## Fix

**`lora_module.py`**: Add `_cuda_supports_bf16()` using `torch.cuda.is_bf16_supported()` — the same pattern already used in `caption_provider_local.py._pick_dtype()`. `_select_compute_dtype` and `_select_fabric_precision` now auto-select `fp16`/`16-mixed` on pre-Ampere GPUs.

**`trainer.py`**: Replace `model.to(dtype)` with a targeted loop that casts only frozen base model weights, leaving adapter params (LoRA/LoKR) in fp32 as required by the AMP GradScaler.

## Result

| GPU | Before | After |
|-----|--------|-------|
| T4, Turing/Volta | Crash (NaN → ValueError) | ✅ Trains with fp16 AMP |
| RTX 3090, A100, Ampere+ | bf16 (unchanged) | ✅ bf16 (unchanged) |

Tested on: NVIDIA T4 (Kaggle free tier, sm_75).
[pr_analysis.md](https://github.com/user-attachments/files/26363034/pr_analysis.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA bf16 device compatibility with enhanced fallback handling for devices without native support
  * Optimized parameter casting during training to preserve adapter parameter precision while maintaining compute efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->