### PR TITLE
feat: wire --precision (auto/bf16/fp16/fp32) through the full training stack

### DIFF
--- a/sidestep_engine/core/lora_module.py
+++ b/sidestep_engine/core/lora_module.py
@@ -94,8 +94,37 @@ def _normalize_device_type(device: Any) -> str:
     return str(device)
 
 
-def _select_compute_dtype(device_type: str) -> torch.dtype:
+
+def _cuda_supports_bf16() -> bool:
+    """Return True only on Ampere+ GPUs (sm_80+) with native bf16 hardware."""
+    if not torch.cuda.is_available():
+        return False
+    try:
+        return torch.cuda.is_bf16_supported()
+    except AttributeError:
+        major, _ = torch.cuda.get_device_capability()
+        return major >= 8
+
+
+def _select_compute_dtype(device_type: str, precision: str = "auto") -> torch.dtype:
+    """Return the torch dtype for model weights and compute.
+
+    Args:
+        device_type: "cuda", "mps", "xpu", or "cpu".
+        precision:   "auto" | "bf16" | "fp16" | "fp32".  When "auto",
+                     selects the best precision for the detected hardware
+                     (bf16 on Ampere+, fp16 on older CUDA/MPS).
+    """
+    if precision == "fp32":
+        return torch.float32
+    if precision == "fp16":
+        return torch.float16
+    if precision == "bf16":
+        return torch.bfloat16
+    # "auto": pick the best dtype the hardware supports
     if device_type in ("cuda", "xpu"):
+        if device_type == "cuda" and not _cuda_supports_bf16():
+            return torch.float16   # T4 / Turing / Volta fallback
         return torch.bfloat16
     if device_type == "mps":
         return torch.float16
@@ -137,7 +166,10 @@ class FixedLoRAModule(nn.Module):
         self.training_config = training_config
         self.device = torch.device(device) if isinstance(device, str) else device
         self.device_type = _normalize_device_type(self.device)
-        self.dtype = _select_compute_dtype(self.device_type)
+        self.dtype = _select_compute_dtype(
+            self.device_type,
+            getattr(training_config, "precision", "auto"),
+        )
         self.transfer_non_blocking = self.device_type in ("cuda", "xpu")
 
         # LyCORIS network reference (only set for LoKR/LoHA)

--- a/sidestep_engine/core/trainer.py
+++ b/sidestep_engine/core/trainer.py
@@ -156,7 +156,10 @@ class FixedLoRATrainer:
 
             # -- Build module -----------------------------------------------
             device = torch.device(cfg.device)
-            dtype = _select_compute_dtype(_normalize_device_type(device))
+            dtype = _select_compute_dtype(
+                _normalize_device_type(device),
+                getattr(cfg, "precision", "auto"),
+            )
 
             self.module = FixedLoRAModule(
                 model=self.model,
@@ -312,7 +315,7 @@ class FixedLoRATrainer:
         if device_type == "cuda":
             torch.cuda.set_device(self.module.device)
 
-        yield TrainingUpdate(0, 0.0, f"[INFO] Starting training (device: {device_type}, precision: bf16-true)", kind="info")
+        yield TrainingUpdate(0, 0.0, f"[INFO] Starting training (device: {device_type}, dtype: {self.module.dtype})", kind="info")
 
         # -- TensorBoard logger ---------------------------------------------
         tb = TrainingLogger(cfg.effective_log_dir)

--- a/sidestep_engine/models/gpu_utils.py
+++ b/sidestep_engine/models/gpu_utils.py
@@ -99,7 +99,15 @@ def detect_gpu(requested_device: str = "auto", requested_precision: str = "auto"
 
     # Resolve precision
     if requested_precision == "auto":
-        if device_type in ("cuda", "xpu"):
+        if device_type == "cuda":
+            # Use native bf16 only on Ampere+ (sm_80+); fall back to fp16 on
+            # older CUDA GPUs (T4/V100/Turing, sm < 8.0) that emulate bf16
+            # through fp32 and overflow with typical loss magnitudes.
+            try:
+                precision = "bf16" if torch.cuda.is_bf16_supported() else "fp16"
+            except Exception:
+                precision = "bf16"  # conservative fallback for non-standard builds
+        elif device_type == "xpu":
             precision = "bf16"
         elif device_type == "mps":
             precision = "fp16"

--- a/sidestep_engine/tui/screens/training_config.py
+++ b/sidestep_engine/tui/screens/training_config.py
@@ -534,15 +534,16 @@ class TrainingConfigScreen(Screen):
             yield Static("Precision:", classes="form-label")
             yield Select(
                 [
-                    ("BF16 (recommended)", "bf16-mixed"),
-                    ("FP16", "16-mixed"),
-                    ("FP32", "32-true"),
+                    ("Auto (recommended)", "auto"),
+                    ("BF16 — Ampere+ GPUs (RTX 3xxx, A100+)", "bf16"),
+                    ("FP16 — Older GPUs (T4, V100, Turing)", "fp16"),
+                    ("FP32 — Full precision / CPU", "fp32"),
                 ],
-                value="bf16-mixed",
+                value="auto",
                 id="select-precision",
             )
         yield Static("Numerical precision for training", classes="form-hint")
-        yield Static("BF16 = fast + stable  |  FP16 = fast, may overflow  |  FP32 = slow, most precise", classes="impact-hint")
+        yield Static("Auto = bf16 on Ampere+, fp16 on T4/Turing  |  Override only if needed", classes="impact-hint")
         
         yield Rule()
         yield Static("Regularization", classes="section-header")


### PR DESCRIPTION
## Summary

`--precision` was already defined in `args.py` and `TrainingConfigV2` but never
connected to the actual training path. This PR wires it end-to-end and fixes
the TUI precision selector whose options used stale Fabric values.

## Changes

**`gpu_utils.py`** — `detect_gpu()` now calls `torch.cuda.is_bf16_supported()`
when `precision=auto` on CUDA. Pre-Ampere GPUs (T4, V100, Turing sm<8.0)
automatically get `fp16` instead of silently emulating bf16 through fp32.

**`lora_module.py`** — Added `_cuda_supports_bf16()` helper; updated
`_select_compute_dtype(device_type, precision='auto')` to honour an explicit
`bf16`/`fp16`/`fp32` choice or fall back to hardware-aware auto-detection.
`FixedLoRAModule.__init__` now reads `precision` from `training_config` so
the dtype is consistent end-to-end.

**`trainer.py`** — Passes `cfg.precision` into `_select_compute_dtype()`;
replaces the hardcoded `'precision: bf16-true'` startup log with the actual
resolved dtype.

**`tui/screens/training_config.py`** — Fixes the Precision Select widget whose
options were stale Fabric values (`bf16-mixed`, `16-mixed`, `32-true`). Now uses
the correct API values (`auto`, `bf16`, `fp16`, `fp32`) with descriptive labels.
Default changed to `auto`.

## Testing

| GPU | `--precision auto` | `--precision fp16` | `--precision bf16` |
|---|---|---|---|
| T4 (sm_75) | selects fp16 ✅ | fp16 ✅ | bf16 (user override) |
| RTX 3090 (sm_86) | selects bf16 ✅ | fp16 ✅ | bf16 ✅ |

Closes #39


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `auto` precision mode (now default) that intelligently selects optimal precision based on GPU capabilities.
  * Expanded precision options: `auto`, `bf16`, `fp16`, `fp32` (replacing previous mixed-precision variants).

* **Bug Fixes**
  * Improved BF16 hardware detection with fallback for non-standard builds; CUDA now selects FP16 when BF16 unsupported.

* **Chores**
  * Training logs now report actual dtype used instead of hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->