### PR TITLE
Dataset & preprocessing UX: trigger tags, mix-from-folders, Preprocess All

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3022,11 +3022,10 @@
           <input class="input" type="text" id="bulk-trigger-tag" placeholder="e.g. suno_v4">
         </div>
         <div class="form-group">
-          <label class="form-group__label">Position</label>
+          <label class="form-group__label">Position in Prompt</label>
           <select class="select" id="bulk-trigger-position">
             <option value="prepend" selected>Prepend (tag before caption)</option>
             <option value="append">Append (tag after caption)</option>
-            <option value="replace">Replace (tag replaces caption)</option>
           </select>
         </div>
         <div style="font-size: var(--font-size-sm); color: var(--muted);" id="bulk-trigger-preview">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1942,6 +1942,10 @@
         <div class="data-table-header">
           <div class="section-header">Audio Library</div>
           <div class="data-table-header__actions">
+            <label class="form-group__label" style="margin: 0; display: inline-flex; align-items: center; gap: 4px; font-weight: normal; text-transform: none;">
+              <input type="checkbox" id="dataset-auto-folder-trigger">
+              Use folder name as Trigger Tag
+            </label>
             <button class="btn btn--sm btn--refresh" id="btn-refresh-audio-library" title="Refresh audio library">R</button>
             <button class="btn btn--sm btn--accent" id="btn-analyze-audio" disabled>Analyze Audio</button>
             <button class="btn btn--sm btn--primary" id="btn-gen-captions" disabled>Generate AI Captions</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1946,6 +1946,7 @@
             <button class="btn btn--sm btn--accent" id="btn-analyze-audio" disabled>Analyze Audio</button>
             <button class="btn btn--sm btn--primary" id="btn-gen-captions" disabled>Generate AI Captions</button>
             <button class="btn btn--sm" id="btn-add-trigger">Add Trigger Tag to All</button>
+            <button class="btn btn--sm btn--primary" id="btn-preprocess-all" disabled>Preprocess All</button>
           </div>
         </div>
         <p style="color: var(--muted); font-size: var(--font-size-sm); margin-bottom: var(--space-md);">

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -230,11 +230,17 @@ const API = (() => {
 
   // ---- Trigger Tag Bulk -------------------------------------------------
 
-  async function bulkWriteTriggerTag(datasetDir, tag, position) {
-    // Scan for ALL audio files (not just those with existing sidecars)
-    const scan = await scanDataset(datasetDir).catch(() => ({ files: [] }));
-    const paths = (scan.files || [])
-      .map(f => f.sidecar_path || f.path.replace(/\.[^.]+$/, '.txt'));
+  async function bulkWriteTriggerTag(datasetDir, tag, position, selectedPaths) {
+    let paths;
+    if (selectedPaths && selectedPaths.length) {
+      // Only apply to selected files — derive sidecar paths
+      paths = selectedPaths.map(p => p.replace(/\.[^.]+$/, '.txt'));
+    } else {
+      // No selection: scan for ALL audio files
+      const scan = await scanDataset(datasetDir).catch(() => ({ files: [] }));
+      paths = (scan.files || [])
+        .map(f => f.sidecar_path || f.path.replace(/\.[^.]+$/, '.txt'));
+    }
     return _post('/api/trigger-tag/bulk', { paths, tag, position });
   }
 
@@ -258,8 +264,8 @@ const API = (() => {
       normalize_alpha: !!normalizeAlpha,
     });
   }
-  async function createMixDataset(sourceRoot, destRoot, mixName, files) {
-    return _post('/api/dataset/mix', { source_root: sourceRoot, destination_root: destRoot, mix_name: mixName, files });
+  async function createMixDataset(sourceRoot, destRoot, mixName, files, sidecarMode) {
+    return _post('/api/dataset/mix', { source_root: sourceRoot, destination_root: destRoot, mix_name: mixName, files, sidecar_mode: sidecarMode || 'copy' });
   }
 
   // ---- File Browser -----------------------------------------------------

--- a/frontend/js/dataset.js
+++ b/frontend/js/dataset.js
@@ -72,6 +72,12 @@ const Dataset = (() => {
     if (ppOut && ppOut.readOnly) {
       ppOut.value = _joinPath($('settings-tensors-dir')?.value || './preprocessed_tensors', _pathBasename(target) || 'tensors');
     }
+    // Auto-fill trigger tag from folder name if checkbox is on
+    const autoTag = document.getElementById('dataset-auto-folder-trigger')?.checked;
+    if (autoTag && folderPath !== '.') {
+      const triggerField = $('pp-trigger-tag');
+      if (triggerField) triggerField.value = folderPath.split('/').pop() || '';
+    }
     if (typeof showToast === 'function') showToast('Preprocess path set from Audio Library folder', 'info');
   }
 
@@ -153,12 +159,18 @@ const Dataset = (() => {
     });
   }
 
+  function _isAutoFolderTrigger() {
+    return !!document.getElementById('dataset-auto-folder-trigger')?.checked;
+  }
+
   function _renderHierarchy(tbody) {
     tbody.innerHTML = '';
     if (_files.length === 0) {
       tbody.innerHTML = '<tr><td colspan="7" class="data-table-empty">No audio files found in the current Audio directory.</td></tr>';
       return;
     }
+
+    const autoTag = _isAutoFolderTrigger();
 
     const map = new Map();
     _folders.forEach((f) => {
@@ -220,13 +232,17 @@ const Dataset = (() => {
       folder.files.sort((a, b) => String(a.name).localeCompare(String(b.name)));
     });
 
-    const appendFile = (f, depth, ancestorPaths) => {
+    const appendFile = (f, depth, ancestorPaths, parentFolderName) => {
       const idx = _files.findIndex((x) => x.path === f.path);
       const sidecarStatus = f.has_sidecar
         ? '<span class="status--ok">[ok] exists</span>'
         : '<span class="status--warn">missing</span>';
       const editLabel = f.has_sidecar ? 'Edit' : 'Create';
       const coverUrl = API.audioCoverUrl(f.path);
+      // Determine trigger tag display: auto-folder wins if checkbox is on
+      const displayTrigger = autoTag && parentFolderName
+        ? `<span class="u-text-secondary">${_esc(parentFolderName)}</span>`
+        : (f.trigger ? _esc(f.trigger) : '<span class="u-text-muted">--</span>');
       const trFile = document.createElement('tr');
       trFile.className = 'dataset-file-row';
       trFile.dataset.apPath = f.path;
@@ -245,7 +261,7 @@ const Dataset = (() => {
         <td>${sidecarStatus}</td>
         <td>${f.genre ? _esc(f.genre) : '<span class="u-text-muted">--</span>'}</td>
         <td>${f.tags ? _esc(f.tags) : '<span class="u-text-muted">--</span>'}</td>
-        <td>${f.trigger ? _esc(f.trigger) : '<span class="u-text-muted">--</span>'}</td>
+        <td>${displayTrigger}</td>
         <td><button class="btn btn--sm sidecar-edit-btn" data-idx="${idx}">${editLabel}</button></td>
       `;
       // Store cover URL for lazy loading (don't fetch until row is visible)
@@ -297,7 +313,7 @@ const Dataset = (() => {
           <td><span class="u-text-muted">${sidecars}/${count} sidecars</span></td>
           <td><span class="u-text-muted">--</span></td>
           <td><span class="u-text-muted">--</span></td>
-          <td>${folder.common_trigger ? `<span class="u-text-secondary">${_esc(folder.common_trigger)}</span>` : '<span class="u-text-muted">--</span>'}</td>
+          <td>${(autoTag ? `<span class="u-text-secondary">${_esc(folder.name || folderPath)}</span>` : (folder.common_trigger ? `<span class="u-text-secondary">${_esc(folder.common_trigger)}</span>` : '<span class="u-text-muted">--</span>'))}</td>
           <td><button class="btn btn--sm" data-action="preprocess-folder" data-folder="${_esc(folderPath)}">Preprocess</button></td>
         `;
         tbody.appendChild(tr);
@@ -307,7 +323,8 @@ const Dataset = (() => {
       const childAncestors = folderPath === '.' ? [] : [...ancestorPaths, folderPath];
 
       folder.children.forEach((child) => appendFolder(child, childAncestors));
-      folder.files.forEach((f) => appendFile(f, folderPath === '.' ? 0 : depth + 1, childAncestors));
+      const folderNameForFiles = folderPath === '.' ? '' : (folder.name || folderPath.split('/').pop() || '');
+      folder.files.forEach((f) => appendFile(f, folderPath === '.' ? 0 : depth + 1, childAncestors, folderNameForFiles));
     };
 
     appendFolder(map.get('.'), []);
@@ -567,10 +584,15 @@ const Dataset = (() => {
       const root = _scanRoot || _canonicalAudioPath();
       if (!root) { if (typeof showToast === 'function') showToast('No audio directory configured', 'warn'); return; }
       // Build items with trigger tags from folder data
+      const autoTag = document.getElementById('dataset-auto-folder-trigger')?.checked;
       const items = paths.map(p => {
         const fullPath = p === '.' ? root : _joinPath(root, p);
         const folder = _folders.find(f => (f.path || '.') === p);
-        return { path: fullPath, triggerTag: folder?.common_trigger || '' };
+        let tConfig = folder?.common_trigger || '';
+        if (autoTag && p !== '.') {
+          tConfig = p.split('/').pop() || tConfig;
+        }
+        return { path: fullPath, triggerTag: tConfig };
       });
       if (items.length === 1) {
         _openPreprocessForFolder(paths[0]);
@@ -644,12 +666,19 @@ const Dataset = (() => {
       const root = _scanRoot || _canonicalAudioPath();
       if (!root) { if (typeof showToast === 'function') showToast('No audio directory configured', 'warn'); return; }
       // Collect all non-root folders with their trigger tags
+      const autoTag = document.getElementById('dataset-auto-folder-trigger')?.checked;
       const items = _folders
         .filter(f => (f.path || '.') !== '.')
-        .map(f => ({
-          path: _joinPath(root, f.path),
-          triggerTag: f.common_trigger || '',
-        }));
+        .map(f => {
+          let tConfig = f.common_trigger || '';
+          if (autoTag) {
+            tConfig = (f.path || '').split('/').pop() || tConfig;
+          }
+          return {
+            path: _joinPath(root, f.path),
+            triggerTag: tConfig,
+          };
+        });
       if (!items.length) {
         // Only root folder — preprocess the root itself
         items.push({ path: root, triggerTag: _folders[0]?.common_trigger || '' });
@@ -1425,6 +1454,13 @@ const Dataset = (() => {
     _initBulkActions();
     _initPreprocessAll();
     _apInit();
+
+    // Re-render the table when the auto-folder-trigger checkbox toggles
+    document.getElementById('dataset-auto-folder-trigger')?.addEventListener('change', () => {
+      const tbody = $('dataset-tbody');
+      if (tbody && _files.length > 0) _renderHierarchy(tbody);
+    });
+
     refreshFromSettings();
   }
 

--- a/frontend/js/dataset.js
+++ b/frontend/js/dataset.js
@@ -403,6 +403,9 @@ const Dataset = (() => {
     _renderHierarchy(tbody);
     if (typeof initShiftClickTable === 'function') initShiftClickTable('dataset-tbody', { requireModifier: true });
     document.dispatchEvent(new CustomEvent('sidestep:dataset-scanned', { detail: { fileCount: _files.length } }));
+    // Enable/disable Preprocess All button based on folder count
+    const ppAllBtn = $('btn-preprocess-all');
+    if (ppAllBtn) ppAllBtn.disabled = _folders.length <= 1; // 1 = root only
   }
 
   async function openEditor(file) {
@@ -495,6 +498,8 @@ const Dataset = (() => {
     }
   }
 
+  function getFolders() { return _folders; }
+
   /* ---- Bulk selection toolbar ---- */
   function _updateBulkToolbar() {
     const toolbar = $('dataset-bulk-toolbar'), countEl = $('dataset-bulk-count'), warnEl = $('dataset-bulk-warn');
@@ -561,14 +566,22 @@ const Dataset = (() => {
       if (!paths.length) { if (typeof showToast === 'function') showToast('Select at least one folder', 'warn'); return; }
       const root = _scanRoot || _canonicalAudioPath();
       if (!root) { if (typeof showToast === 'function') showToast('No audio directory configured', 'warn'); return; }
-      const fullPaths = paths.map(p => p === '.' ? root : _joinPath(root, p));
-      if (fullPaths.length === 1) {
+      // Build items with trigger tags from folder data
+      const items = paths.map(p => {
+        const fullPath = p === '.' ? root : _joinPath(root, p);
+        const folder = _folders.find(f => (f.path || '.') === p);
+        return { path: fullPath, triggerTag: folder?.common_trigger || '' };
+      });
+      if (items.length === 1) {
         _openPreprocessForFolder(paths[0]);
+        // Also set trigger tag if available
+        const triggerField = $('pp-trigger-tag');
+        if (triggerField && items[0].triggerTag) triggerField.value = items[0].triggerTag;
       } else {
         _setActiveLabPanel('preprocess');
         if (typeof WorkspaceLab !== 'undefined' && WorkspaceLab.queuePreprocess) {
-          WorkspaceLab.queuePreprocess(fullPaths);
-          showToast(fullPaths.length + ' folders queued for preprocessing', 'ok');
+          WorkspaceLab.queuePreprocess(items);
+          showToast(items.length + ' folders queued for preprocessing', 'ok');
         } else {
           _openPreprocessForFolder(paths[0]);
         }
@@ -621,6 +634,32 @@ const Dataset = (() => {
         }
       } catch (e) {
         showToast('Mix failed: ' + e.message, 'error');
+      }
+    });
+  }
+
+  /* ---- Preprocess All button ---- */
+  function _initPreprocessAll() {
+    $('btn-preprocess-all')?.addEventListener('click', () => {
+      const root = _scanRoot || _canonicalAudioPath();
+      if (!root) { if (typeof showToast === 'function') showToast('No audio directory configured', 'warn'); return; }
+      // Collect all non-root folders with their trigger tags
+      const items = _folders
+        .filter(f => (f.path || '.') !== '.')
+        .map(f => ({
+          path: _joinPath(root, f.path),
+          triggerTag: f.common_trigger || '',
+        }));
+      if (!items.length) {
+        // Only root folder — preprocess the root itself
+        items.push({ path: root, triggerTag: _folders[0]?.common_trigger || '' });
+      }
+      _setActiveLabPanel('preprocess');
+      if (typeof WorkspaceLab !== 'undefined' && WorkspaceLab.queuePreprocess) {
+        WorkspaceLab.queuePreprocess(items);
+        showToast(items.length + ' folder' + (items.length > 1 ? 's' : '') + ' queued for preprocessing', 'ok');
+      } else {
+        _openPreprocessForFolder('.');
       }
     });
   }
@@ -1384,6 +1423,7 @@ const Dataset = (() => {
     document.addEventListener('sidestep:settings-saved', () => refreshFromSettings(true));
 
     _initBulkActions();
+    _initPreprocessAll();
     _apInit();
     refreshFromSettings();
   }
@@ -1395,6 +1435,6 @@ const Dataset = (() => {
     await scan(path);
   }
 
-  return { init, scan, openEditor, closeEditor, refreshFromSettings, getSelectedAudioPaths, hasSelection, bootBeep: _apBootBeep, reopen: _apReopen };
+  return { init, scan, openEditor, closeEditor, refreshFromSettings, getSelectedAudioPaths, hasSelection, getFolders, bootBeep: _apBootBeep, reopen: _apReopen };
 
 })();

--- a/frontend/js/dataset.js
+++ b/frontend/js/dataset.js
@@ -509,7 +509,7 @@ const Dataset = (() => {
     if (folders.length) parts.push(folders.length + ' folder' + (folders.length > 1 ? 's' : ''));
     if (files) parts.push(files + ' file' + (files > 1 ? 's' : ''));
     if (countEl) countEl.textContent = parts.join(', ') + ' selected';
-    if (mixBtn) mixBtn.style.display = files > 0 ? '' : 'none';
+    if (mixBtn) mixBtn.style.display = (files > 0 || folders.length > 0) ? '' : 'none';
     if (warnEl) {
       warnEl.textContent = '';
       warnEl.style.display = 'none';
@@ -552,7 +552,8 @@ const Dataset = (() => {
     if (tbody) new MutationObserver(_updateBulkToolbar).observe(tbody, { attributes: true, attributeFilter: ['class'], subtree: true });
     $('dataset-bulk-clear')?.addEventListener('click', () => { document.querySelectorAll('#dataset-tbody tr.selected').forEach((r) => r.classList.remove('selected')); _updateBulkToolbar(); });
     $('dataset-bulk-trigger')?.addEventListener('click', () => {
-      if (!_getSelectedFolderPaths().length) { if (typeof showToast === 'function') showToast('Select at least one folder', 'warn'); return; }
+      if (!_getSelectedFolderPaths().length && !_getSelectedFilePaths().length) { if (typeof showToast === 'function') showToast('Select files or folders first', 'warn'); return; }
+      if (typeof WorkspaceLab !== 'undefined' && WorkspaceLab._updateTriggerModalScope) WorkspaceLab._updateTriggerModalScope();
       $('trigger-tag-modal')?.classList.add('open');
     });
     $('dataset-bulk-preprocess')?.addEventListener('click', () => {
@@ -575,17 +576,34 @@ const Dataset = (() => {
     });
 
     $('dataset-bulk-mix')?.addEventListener('click', async () => {
-      const filePaths = _getSelectedFilePaths();
-      if (!filePaths.length) { if (typeof showToast === 'function') showToast('Select individual audio files to create a mix', 'warn'); return; }
+      const filePaths = getSelectedAudioPaths();
+      if (!filePaths.length) { if (typeof showToast === 'function') showToast('Select files or folders to create a mix', 'warn'); return; }
       const defaultName = 'mix_' + filePaths.length + '_tracks';
       const mixName = typeof WorkspaceBehaviors !== 'undefined' && WorkspaceBehaviors.showPromptModal
         ? await WorkspaceBehaviors.showPromptModal('Create Mix Dataset', 'Name for the mix dataset:', defaultName)
         : prompt('Name for the mix dataset:', defaultName);
       if (!mixName) return;
+      // Ask about sidecar handling
+      let sidecarMode = 'empty';
+      const hasSidecars = filePaths.some((fp) => {
+        const f = _files.find((x) => x.path === fp);
+        return f && f.has_sidecar;
+      });
+      if (hasSidecars && typeof WorkspaceBehaviors !== 'undefined' && WorkspaceBehaviors.showConfirmModal) {
+        sidecarMode = await new Promise((resolve) => {
+          WorkspaceBehaviors.showConfirmModal(
+            'Sidecar Metadata',
+            'Some selected tracks have existing sidecar metadata (.txt). Copy them into the mix, or start fresh with empty sidecars?',
+            'Copy Existing',
+            () => resolve('copy'),
+            () => resolve('empty'),
+          );
+        });
+      }
       const root = _scanRoot || _canonicalAudioPath();
       const destRoot = $('settings-audio-dir')?.value || root || '.';
       try {
-        const result = await API.createMixDataset(root, destRoot, mixName, filePaths);
+        const result = await API.createMixDataset(root, destRoot, mixName, filePaths, sidecarMode);
         if (result.ok) {
           const n = Number(result.created || 0);
           if (!n && filePaths.length) {

--- a/frontend/js/workspace-lab.js
+++ b/frontend/js/workspace-lab.js
@@ -198,6 +198,7 @@ const WorkspaceLab = (() => {
       normalize: normMethod, trigger_tag: $("pp-trigger-tag")?.value, tag_position: $("pp-tag-position")?.value,
       target_db: normMethod === "peak" ? parseFloat($("pp-peak-target")?.value) || -1.0 : -1.0,
       target_lufs: normMethod === "lufs" ? parseFloat($("pp-lufs-target")?.value) || -14.0 : -14.0,
+      genre_ratio: parseInt($("pp-genre-ratio")?.value) || 0,
     };
 
     const prog = $("pp-progress-panel"); if (prog) prog.style.display = "block";

--- a/frontend/js/workspace-lab.js
+++ b/frontend/js/workspace-lab.js
@@ -155,7 +155,8 @@ const WorkspaceLab = (() => {
         : item.status === "running" ? '<span class="u-text-primary">[...]</span>'
         : '<span class="u-text-muted">[--]</span>';
       const name = _pathBasename(item.audioDir);
-      return `<div style="padding:2px 0;">${icon} ${_e(name)} <span class="u-text-muted">${_e(item.status)}</span></div>`;
+      const tag = item.triggerTag ? ` <span class="u-text-muted">[${_e(item.triggerTag)}]</span>` : '';
+      return `<div style="padding:2px 0;">${icon} ${_e(name)}${tag} <span class="u-text-muted">${_e(item.status)}</span></div>`;
     }).join("");
   }
 
@@ -186,6 +187,9 @@ const WorkspaceLab = (() => {
     const ppOut = $("pp-output-dir");
     if (ppAudio) { ppAudio.value = next.audioDir; ppAudio.dispatchEvent(new Event("change")); }
     if (ppOut && ppOut.readOnly) ppOut.value = next.outputDir;
+    // Auto-populate trigger tag from per-item data
+    const triggerField = $("pp-trigger-tag");
+    if (triggerField && next.triggerTag != null) triggerField.value = next.triggerTag;
 
     const normMethod = $("pp-normalize")?.value || "none";
     const config = {
@@ -236,10 +240,14 @@ const WorkspaceLab = (() => {
 
   function queuePreprocess(folderPaths) {
     const tensorsDir = $("settings-tensors-dir")?.value || Defaults.get("settings-tensors-dir") || "preprocessed_tensors";
-    folderPaths.forEach(audioDir => {
+    folderPaths.forEach(item => {
+      const isObj = typeof item === 'object' && item !== null;
+      const audioDir = isObj ? item.path : item;
+      const triggerTag = isObj ? (item.triggerTag || '') : '';
       _ppQueue.push({
         audioDir,
         outputDir: _joinPath(tensorsDir, _pathBasename(audioDir) || "tensors"),
+        triggerTag,
         status: "pending",
       });
     });

--- a/frontend/js/workspace-lab.js
+++ b/frontend/js/workspace-lab.js
@@ -821,6 +821,7 @@ const WorkspaceLab = (() => {
   /* ---- Trigger Tag Bulk Modal ---- */
   function initTriggerTagBulk() {
     $("btn-add-trigger")?.addEventListener("click", () => {
+      _updateTriggerModalScope();
       $("trigger-tag-modal")?.classList.add("open");
     });
     $("trigger-tag-close")?.addEventListener("click", () => {
@@ -838,11 +839,29 @@ const WorkspaceLab = (() => {
       const position = $("bulk-trigger-position")?.value;
       const dsPath = $("lab-dataset-path")?.value;
       if (!tag) { showToast("Enter a trigger tag", "warn"); return; }
-      const result = await API.bulkWriteTriggerTag(dsPath, tag, position);
+      // Use selected files when available, otherwise apply to all
+      const selected = (typeof Dataset !== "undefined" && Dataset.hasSelection && Dataset.hasSelection())
+        ? Dataset.getSelectedAudioPaths()
+        : null;
+      const result = await API.bulkWriteTriggerTag(dsPath, tag, position, selected);
       $("trigger-tag-modal")?.classList.remove("open");
-      showToast(`Trigger tag written to ${result.updated} sidecars`, "ok");
+      const scope = selected && selected.length ? `${result.updated} selected` : `${result.updated}`;
+      showToast(`Trigger tag written to ${scope} sidecars`, "ok");
       if (typeof Dataset !== "undefined") Dataset.scan(dsPath);
     });
+  }
+
+  function _updateTriggerModalScope() {
+    const hasSel = typeof Dataset !== 'undefined' && Dataset.hasSelection && Dataset.hasSelection();
+    const count = hasSel ? Dataset.getSelectedAudioPaths().length : 0;
+    const titleEl = document.querySelector('#trigger-tag-modal .modal__title');
+    const applyBtn = $('btn-bulk-trigger-apply');
+    const descEl = document.querySelector('#trigger-tag-modal .modal__body > p');
+    if (titleEl) titleEl.textContent = hasSel ? `Add Trigger Tag to ${count} Selected File${count !== 1 ? 's' : ''}` : 'Add Trigger Tag to All Files';
+    if (applyBtn) applyBtn.textContent = hasSel ? `Apply to ${count} Selected` : 'Apply to All Files';
+    if (descEl) descEl.innerHTML = hasSel
+      ? `This writes the trigger tag into the <strong>${count}</strong> selected sidecar${count !== 1 ? 's' : ''}. Existing tags will be overwritten.`
+      : 'This writes the trigger tag into every .txt sidecar in the dataset folder. Existing tags will be overwritten. Files without sidecars will get a new .txt file.';
   }
 
   function _updateTriggerPreview() {
@@ -928,5 +947,5 @@ const WorkspaceLab = (() => {
     _updateAnalyzeButtonStates();
   }
 
-  return { init, queuePreprocess };
+  return { init, queuePreprocess, _updateTriggerModalScope };
 })();

--- a/sidestep_engine/data/dataset_builder.py
+++ b/sidestep_engine/data/dataset_builder.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # Aliases are mapped to their canonical name by _SIDECAR_ALIASES.
 _KNOWN_SIDECAR_KEYS = frozenset({
     "caption", "genre", "bpm", "key", "signature", "lyrics",
-    "tags", "custom_tag", "trigger", "is_instrumental",
+    "tags", "custom_tag", "trigger", "tag_position", "is_instrumental",
     "repeat", "prompt_override", "duration",
     # Aliases
     "keyscale", "scale",

--- a/sidestep_engine/data/preprocess_prompt.py
+++ b/sidestep_engine/data/preprocess_prompt.py
@@ -43,6 +43,9 @@ def build_simple_prompt(
     override = meta.get("prompt_override")
     tag = meta.get("custom_tag") or meta.get("trigger", "")
 
+    # Per-sample tag_position overrides the dataset-level default
+    tag_position = meta.get("tag_position") or tag_position
+
     # Decide caption vs genre (mirrors AudioSample.get_training_prompt)
     if override == "genre":
         text = genre
@@ -57,8 +60,6 @@ def build_simple_prompt(
             text = f"{tag}, {text}" if text else tag
         elif tag_position == "append":
             text = f"{text}, {tag}" if text else tag
-        elif tag_position == "replace":
-            text = tag
 
     bpm = meta.get("bpm", "N/A") or "N/A"
     ts = meta.get("timesignature", "N/A") or "N/A"

--- a/sidestep_engine/data/sidecar_metadata.py
+++ b/sidestep_engine/data/sidecar_metadata.py
@@ -84,6 +84,7 @@ def normalize_sidecar(raw: Dict[str, Any], audio_path: Path) -> Dict[str, Any]:
         "duration": _parse_duration(raw.get("duration", "")),
         "is_instrumental": is_instrumental,
         "custom_tag": raw.get("custom_tag", raw.get("trigger", "")),
+        "tag_position": raw.get("tag_position", ""),
         "prompt_override": raw.get("prompt_override"),
     }
 

--- a/sidestep_engine/gui/file_ops.py
+++ b/sidestep_engine/gui/file_ops.py
@@ -486,24 +486,24 @@ def scan_audio_dir(path: str) -> Dict[str, Any]:
 
 
 def _link_or_copy_mix_file(src: Path, dest: Path) -> None:
-    """Create *dest* pointing at *src*: symlink, else hard link, else copy.
+    """Link *src* to *dest* using the best available method.
 
-    Windows often denies symlinks without Developer Mode / elevation; hard links
-    and copies keep mix datasets usable without extra privileges.
+    Tries in order: symlink → hard link → file copy.
+    Raises OSError only if all three methods fail.
     """
-    if dest.exists():
-        return
-    dest.parent.mkdir(parents=True, exist_ok=True)
+    # 1. symlink (cheapest, but needs privileges on Windows)
     try:
         os.symlink(str(src), str(dest))
         return
     except OSError:
         pass
+    # 2. hard link (works on same volume without special privileges)
     try:
         os.link(str(src), str(dest))
         return
     except OSError:
         pass
+    # 3. full copy (always works, uses more disk)
     shutil.copy2(str(src), str(dest))
 
 
@@ -512,11 +512,22 @@ def create_mix_dataset(
     destination_root: str,
     mix_name: str,
     files: List[str],
+    sidecar_mode: str = "copy",
 ) -> Dict[str, Any]:
-    """Create a mixed dataset by linking selected audio files into one folder.
+    """Create a mixed dataset from selected files and/or folders.
 
-    Prefers symlinks (space-efficient); falls back to hard links or file copies
-    when the OS disallows symlinks (common on Windows without Developer Mode).
+    Audio files are linked (symlink → hard-link → copy fallback) so the
+    mix is storage-light when possible.  Sidecar ``.txt`` files are always
+    independent copies so the user can edit them freely.
+
+    Args:
+        source_root: Audio library root used to compute relative paths.
+        destination_root: Parent directory where the new mix folder is placed.
+        mix_name: Human-readable name (sanitised for the filesystem).
+        files: List of absolute paths — may be individual audio files **or**
+            directories whose audio contents will be included recursively.
+        sidecar_mode: ``"copy"`` to duplicate existing sidecar content,
+            ``"empty"`` to create blank ``.txt`` files for every track.
     """
     src_root = _resolve_gui_path(source_root)
     dest_root = _resolve_gui_path(destination_root)
@@ -525,7 +536,6 @@ def create_mix_dataset(
         return {"ok": False, "error": "Missing mix_name"}
     if not src_root.is_dir():
         return {"ok": False, "error": f"Invalid source root: {src_root}"}
-    src_root_res = src_root.resolve(strict=False)
     if not dest_root.exists():
         try:
             dest_root.mkdir(parents=True, exist_ok=True)
@@ -547,49 +557,59 @@ def create_mix_dataset(
     if out_dir.exists() and any(out_dir.iterdir()):
         return {"ok": False, "error": f"Destination already exists and is not empty: {out_dir}"}
 
+    # -- Expand entries: folders → contained audio files, files pass through --
+    audio_paths: List[Path] = []
+    for raw in files or []:
+        p = _resolve_gui_path(raw)
+        if p.is_dir():
+            audio_paths.extend(
+                sorted(f for f in p.rglob("*") if f.is_file() and f.suffix.lower() in _AUDIO_EXTS)
+            )
+        elif p.is_file() and p.suffix.lower() in _AUDIO_EXTS:
+            audio_paths.append(p)
+
+    if not audio_paths:
+        return {"ok": False, "error": "No audio files found in the selection"}
+
     out_dir.mkdir(parents=True, exist_ok=True)
 
     created = 0
     skipped = 0
     errors: List[str] = []
 
-    for raw in files or []:
-        src = _resolve_gui_path(raw)
-        if src.suffix.lower() not in _AUDIO_EXTS:
-            skipped += 1
-            continue
-        if not src.is_file():
-            skipped += 1
-            continue
-        try:
-            src_res = src.resolve(strict=False)
-            rel = src_res.relative_to(src_root_res)
-        except ValueError:
-            skipped += 1
-            continue
-
-        dest_audio = out_dir / rel
-        dest_audio.parent.mkdir(parents=True, exist_ok=True)
+    for src in audio_paths:
+        dest_audio = out_dir / src.name
         if dest_audio.exists():
             skipped += 1
             continue
 
         try:
-            _link_or_copy_mix_file(src_res, dest_audio)
+            _link_or_copy_mix_file(src, dest_audio)
             created += 1
         except OSError as exc:
             errors.append(f"{src.name}: {exc}")
             continue
 
-        src_sidecar = src_res.with_suffix(".txt")
-        if src_sidecar.is_file():
-            dest_sidecar = dest_audio.with_suffix(".txt")
-            if not dest_sidecar.exists():
+        # -- Sidecar handling: always an independent file, never a link --
+        dest_sidecar = dest_audio.with_suffix(".txt")
+        if not dest_sidecar.exists():
+            src_sidecar = src.with_suffix(".txt")
+            if sidecar_mode == "copy" and src_sidecar.is_file():
                 try:
-                    _link_or_copy_mix_file(src_sidecar, dest_sidecar)
+                    shutil.copy2(str(src_sidecar), str(dest_sidecar))
                 except OSError:
-                    # Sidecar failures should not fail the whole mix.
-                    pass
+                    dest_sidecar.write_text("", encoding="utf-8")
+            else:
+                dest_sidecar.write_text("", encoding="utf-8")
+
+    if created == 0:
+        # Clean up the empty directory we created
+        try:
+            shutil.rmtree(str(out_dir), ignore_errors=True)
+        except Exception:
+            pass
+        summary = "; ".join(errors[:5]) if errors else "unknown"
+        return {"ok": False, "error": f"Could not link any files: {summary}"}
 
     return {
         "ok": True,
@@ -704,13 +724,10 @@ def bulk_apply_trigger_tag(paths: List[str], tag: str, position: str) -> Dict[st
         try:
             pp = _coerce_sidecar_path(p)
             data = _read(pp)
-            existing = str(data.get("custom_tag") or data.get("trigger") or "").strip()
-            if position == "prepend":
-                data["custom_tag"] = f"{tag} {existing}".strip()
-            elif position == "append":
-                data["custom_tag"] = f"{existing} {tag}".strip()
-            elif position == "replace":
-                data["custom_tag"] = tag
+            # Overwrite: new tag replaces any existing custom_tag/trigger
+            data["custom_tag"] = tag
+            if position in ("prepend", "append"):
+                data["tag_position"] = position
             data.pop("trigger", None)
             _write(pp, data)
             updated += 1

--- a/sidestep_engine/gui/server.py
+++ b/sidestep_engine/gui/server.py
@@ -104,6 +104,7 @@ class MixDatasetRequest(BaseModel):
     destination_root: str
     mix_name: str
     files: List[str]
+    sidecar_mode: str = "copy"
 
 
 class LinkSourceAudioRequest(BaseModel):
@@ -471,6 +472,7 @@ def create_app(token: str | None = None, port: int = 8770) -> FastAPI:
             destination_root=body.destination_root,
             mix_name=body.mix_name,
             files=body.files,
+            sidecar_mode=body.sidecar_mode,
         ))
 
     @app.post("/api/open-folder")


### PR DESCRIPTION
# Dataset & preprocessing UX: trigger tags, mix-from-folders, Preprocess All

Builds on the #52 Windows mix fix and extends the Audio Library workflow.

**Trigger tags**
- Bulk apply now *overwrites* existing tags (the old prepend/append-to-existing behavior produced tag soup on re-apply); prepend/append is stored as a per-file `tag_position` in the sidecar and honored during preprocessing.
- Applies to the current file selection when one exists, whole folder otherwise (modal shows its scope).
- `tag_position` added to `_KNOWN_SIDECAR_KEYS` (was silently discarded by the sidecar parser).
- The confusing "Replace" position option is gone — overwrite semantics made it redundant.
- New auto-trigger checkbox previews folder names as trigger tags directly in the Audio Library table.

**Mix datasets**
- Selections may now include whole folders (recursively expanded to their audio files).
- Output is flattened by filename; audio is linked via the existing symlink→hardlink→copy ladder from #52.
- Sidecars are always independent *copies*, never links (so editing a mix's captions can't corrupt the source dataset), with a copy-existing / start-empty choice (`sidecar_mode` API param).
- A run that links zero files cleans up its empty directory and reports the first errors instead of leaving a husk.

**Preprocess All**
- One button queues every folder for preprocessing with per-folder trigger-tag auto-population; queue config includes `genre_ratio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Preprocess All** to the Audio Library.
  * Added an option to derive trigger tags automatically from folder names.
  * Bulk trigger-tag updates can now target selected files or the entire library.
  * Mix dataset creation now lets you copy existing sidecar metadata or start with blank sidecars.
  * Preprocessing queues preserve per-item trigger tags.

* **Updates**
  * Renamed trigger-tag placement control to **Position in Prompt**.
  * Trigger tags now support **Prepend** and **Append** placement only.
  * Sidecar metadata preserves trigger-tag placement settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->