### PR TITLE
Planner-LM adapter training: lm-train, lm-batch, --lm-train chaining

### DIFF
--- a/sidestep_engine/cli/args.py
+++ b/sidestep_engine/cli/args.py
@@ -115,6 +115,13 @@ def build_root_parser() -> argparse.ArgumentParser:
     )
     _add_common_training_args(p_train)
     _add_train_args(p_train)
+    g_lm_chain = p_train.add_argument_group("Planner LM chaining")
+    g_lm_chain.add_argument(
+        "--lm-train", type=str, default="off", choices=["off", "before", "after"],
+        dest="lm_train",
+        help="Also train a 5Hz planner LM adapter before or after DiT training (default: off)",
+    )
+    _add_lm_args(p_train)
 
     # -- preprocess (promoted to top-level) ----------------------------------
     p_preprocess = subparsers.add_parser(
@@ -123,6 +130,43 @@ def build_root_parser() -> argparse.ArgumentParser:
         formatter_class=formatter_class,
     )
     _add_preprocess_subcommand_args(p_preprocess)
+
+    # -- lm-train (5Hz planner LM adapters) ---------------
+    p_lm = subparsers.add_parser(
+        "lm-train",
+        help="Train a LoRA adapter for the ACE-Step 5Hz planner LM (extract -> train -> export)",
+        formatter_class=formatter_class,
+    )
+    _add_model_args(p_lm)
+    _add_device_args(p_lm)
+    g_lm_io = p_lm.add_argument_group("Data / output")
+    g_lm_io.add_argument("--dataset-dir", "-d", type=str, default=None,
+                         help="Preprocessed tensor dataset directory (same one used for DiT training)")
+    g_lm_io.add_argument("--output-dir", "-o", type=str, default=None,
+                         help="Output directory for the LM adapter + code JSONL")
+    _add_lm_args(p_lm)
+    g_lm_st = p_lm.add_argument_group("Stages")
+    g_lm_st.add_argument("--lm-stages", type=str, default="all",
+                         help="Pipeline stages: all, or comma list of extract,train,export (default: all)")
+
+    # -- lm-batch (planner-LM adapters for ALL datasets) ----------------------
+    p_lmb = subparsers.add_parser(
+        "lm-batch",
+        help="Batch planner-LM adapters for every preprocessed dataset (burst extract/train, resumable, watch mode)",
+        formatter_class=formatter_class,
+    )
+    _add_model_args(p_lmb)
+    _add_device_args(p_lmb)
+    g_lmb = p_lmb.add_argument_group("Batch")
+    g_lmb.add_argument("--tensors-root", type=str, required=True,
+                       help="Root containing one preprocessed dataset dir per artist")
+    g_lmb.add_argument("--output-root", type=str, required=True,
+                       help="Root for per-dataset training outputs + batch log")
+    g_lmb.add_argument("--watch", action="store_true", default=False,
+                       help="Keep polling for datasets as a concurrent preprocessing job completes them")
+    g_lmb.add_argument("--idle-exit-mins", type=int, default=120,
+                       help="Watch mode: exit after this many idle minutes (default: 120)")
+    _add_lm_args(p_lmb)
 
     # -- analyze (was: fisher) -----------------------------------------------
     p_analyze = subparsers.add_parser(
@@ -323,6 +367,40 @@ def build_root_parser() -> argparse.ArgumentParser:
 # ===========================================================================
 # Argument groups
 # ===========================================================================
+
+def _add_lm_args(parser: argparse.ArgumentParser) -> None:
+    """LM (5Hz planner) adapter hyperparameters.
+
+    Shared between the standalone ``lm-train`` subcommand and the DiT
+    ``train`` subcommand (for ``--lm-train before|after`` chaining), so
+    dest names — and therefore GUI/preset JSON keys — are identical.
+    """
+    g = parser.add_argument_group("Planner LM adapter")
+    g.add_argument("--lm-size", type=str, default="4B", choices=["0.6B", "1.7B", "4B"],
+                   help="Which acestep-5Hz-lm base to adapt (default: 4B)")
+    g.add_argument("--lm-rank", type=int, default=16, help="LoRA rank (default: 16)")
+    g.add_argument("--lm-alpha", type=int, default=32, help="LoRA alpha (default: 32)")
+    g.add_argument("--lm-dropout", type=float, default=0.05, help="LoRA dropout (default: 0.05)")
+    g.add_argument("--lm-lr", type=float, default=1e-4, help="Learning rate (default: 1e-4)")
+    g.add_argument("--lm-epochs", type=int, default=4, help="Training epochs (default: 4 — small data overfits fast). With --lm-target-loss this is the safety CAP")
+    g.add_argument("--lm-target-loss", type=float, default=0.0,
+                   help="Stop when the epoch's mean CE/token reaches this (0 = off). Normalizes fit across dataset sizes; ~4.0 recommended")
+    g.add_argument("--lm-grad-accum", type=int, default=4, help="Gradient accumulation (default: 4)")
+    g.add_argument("--lm-max-len", type=int, default=8192,
+                   help="Skip songs whose prompt+codes exceed this token count (default: 8192)")
+    g.add_argument("--lm-loss-on-cot", action=argparse.BooleanOptionalAction, default=True,
+                   help="Also train the CoT metas block (artist-typical bpm/keys; default: True)")
+    g.add_argument("--lm-seed", type=int, default=42, help="Training seed (default: 42)")
+    g.add_argument("--lm-export-name", type=str, default=None,
+                   help="Name for the exported adapter/model (default: run name)")
+    g.add_argument("--lm-export-mode", type=str, default="adapter", choices=["adapter", "merged", "both"],
+                   help="adapter: deploy PEFT dir to the models root's adapters/lm/ for runtime LoRA (default); "
+                        "merged: bake a full merged HF model into models/; both: do both")
+    g.add_argument("--lm-models-root", type=str, default=None,
+                   help="Override the export destination root (default: derived from checkpoint dir)")
+    g.add_argument("--lm-refresh-codes", action="store_true", default=False,
+                   help="Re-run code extraction even if a cached lm_codes.jsonl exists")
+
 
 def _add_model_args(parser: argparse.ArgumentParser) -> None:
     """Add --model (was --model-variant) and --checkpoint-dir."""

--- a/sidestep_engine/cli/train_fixed.py
+++ b/sidestep_engine/cli/train_fixed.py
@@ -78,6 +78,56 @@ def _session_artifact_paths(train_cfg: Any, session_name: str) -> tuple[Path, Pa
     )
 
 
+def _run_lm_chain(args: argparse.Namespace, train_cfg: Any, session_ui_log_path) -> int:
+    """Run the planner LM adapter pipeline as a subprocess.
+
+    A subprocess guarantees a clean VRAM lifecycle on both sides of the
+    DiT run and streams its stdout into the same console/GUI log.
+    """
+    import subprocess
+
+    train_py = Path(__file__).resolve().parents[2] / "train.py"
+    lm_out = str(Path(train_cfg.output_dir) / "lm")
+    export_name = getattr(args, "lm_export_name", None) or Path(train_cfg.output_dir).name
+
+    cmd = [
+        sys.executable, str(train_py), "lm-train", "--plain", "--yes",
+        "--checkpoint-dir", str(train_cfg.checkpoint_dir),
+        "--model", str(train_cfg.model_variant),
+        "--dataset-dir", str(train_cfg.dataset_dir),
+        "--output-dir", lm_out,
+        "--device", str(train_cfg.device),
+        "--precision", str(train_cfg.precision),
+        "--lm-size", str(getattr(args, "lm_size", "4B")),
+        "--lm-rank", str(getattr(args, "lm_rank", 16)),
+        "--lm-alpha", str(getattr(args, "lm_alpha", 32)),
+        "--lm-dropout", str(getattr(args, "lm_dropout", 0.05)),
+        "--lm-lr", str(getattr(args, "lm_lr", 1e-4)),
+        "--lm-epochs", str(getattr(args, "lm_epochs", 4)),
+        "--lm-grad-accum", str(getattr(args, "lm_grad_accum", 4)),
+        "--lm-max-len", str(getattr(args, "lm_max_len", 8192)),
+        "--lm-seed", str(getattr(args, "lm_seed", 42)),
+        "--lm-target-loss", str(getattr(args, "lm_target_loss", 0.0)),
+        "--lm-export-name", export_name,
+        "--lm-export-mode", str(getattr(args, "lm_export_mode", "adapter")),
+    ]
+    if not getattr(args, "lm_loss_on_cot", True):
+        cmd.append("--no-lm-loss-on-cot")
+    if getattr(args, "lm_refresh_codes", False):
+        cmd.append("--lm-refresh-codes")
+    if getattr(args, "lm_models_root", None):
+        cmd += ["--lm-models-root", str(args.lm_models_root)]
+
+    show_info(f"Planner LM adapter: launching chained run -> {lm_out}")
+    if session_ui_log_path is not None:
+        _append_session_log(session_ui_log_path, f"[INFO] Planner LM chain: {' '.join(cmd[2:])}")
+    proc = subprocess.run(cmd)
+    if session_ui_log_path is not None:
+        level = "[OK]" if proc.returncode == 0 else "[WARN]"
+        _append_session_log(session_ui_log_path, f"{level} Planner LM chain finished (rc={proc.returncode})")
+    return proc.returncode
+
+
 def _append_session_log(path: Path, msg: str) -> None:
     """Append one timestamped line to the session UI log."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -250,6 +300,13 @@ def run_fixed(args: argparse.Namespace) -> int:
             level = "[OK]" if launched else "[WARN]"
             _append_session_log(session_ui_log_path, f"{level} {launch_msg}")
 
+    # -- Planner LM chaining: BEFORE DiT training --------
+    _lm_when = getattr(args, "lm_train", "off") or "off"
+    if _lm_when == "before":
+        rc = _run_lm_chain(args, train_cfg, session_ui_log_path)
+        if rc != 0:
+            show_info(f"[WARN] Planner LM training failed (rc={rc}) — continuing with DiT training")
+
     model = None
     trainer = None
     try:
@@ -321,6 +378,16 @@ def run_fixed(args: argparse.Namespace) -> int:
                 _append_session_log(session_ui_log_path, f"[FAIL] Training failed: {exc}")
             handle_error(exc, context="Training", show_traceback=True)
             return 1
+
+        # -- Planner LM chaining: AFTER DiT training -----
+        if _lm_when == "after":
+            # Free the DiT model FIRST — the LM subprocess needs the VRAM.
+            trainer = None
+            model = None
+            _cleanup_gpu()
+            rc = _run_lm_chain(args, train_cfg, session_ui_log_path)
+            if rc != 0:
+                show_info(f"[WARN] Planner LM training failed (rc={rc}) — DiT adapter is unaffected")
 
         return 0
     finally:

--- a/sidestep_engine/lm/__init__.py
+++ b/sidestep_engine/lm/__init__.py
@@ -1,0 +1,11 @@
+"""LM (planner) adapter training for the ACE-Step 5Hz language model.
+
+
+Trains LoRA adapters for the ``acestep-5Hz-lm-*`` planner so that song
+structure / phrasing / vocal placement can be specialized per artist,
+complementing the DiT adapter (which captures timbre/production).
+
+Pipeline: extract (dataset songs -> code-sequence JSONL) -> train (PEFT
+LoRA SFT) -> export (PEFT adapter and/or merged HF checkpoint dir into
+the models root, where a compatible inference engine loads it directly).
+"""

--- a/sidestep_engine/lm/batch.py
+++ b/sidestep_engine/lm/batch.py
@@ -1,0 +1,230 @@
+"""Batch driver: planner-LM adapters for every preprocessed dataset.
+
+Sweeps a tensors root (e.g. ``M:/preprocessed_tensors/thirds``) and for each
+complete dataset runs extract -> train -> export. Engineered for a 185-dataset
+overnight campaign:
+
+- **Burst extraction**: the full DiT model is loaded ONCE per sweep and shared
+  across every pending dataset's code extraction (saves ~1-2 min/dataset),
+  then freed before training.
+- **Burst training**: the base 4B LM is loaded ONCE per sweep; each dataset
+  wraps it in a fresh PEFT LoRA, trains, saves, and unloads the wrapper to
+  restore the shared base (saves ~1 min/dataset).
+- **Resumable**: datasets whose adapter is already deployed in
+  ``<models root>/adapters/lm/`` are skipped; failures are marked with a
+  ``lm_batch_failed.marker`` in the dataset's output dir and skipped on later
+  sweeps (delete the marker to retry). Safe to kill and relaunch anytime.
+- **Watch mode**: keeps polling for datasets as a concurrently-running
+  preprocessing job completes them (a dataset is "complete" when
+  ``preprocess_meta.json`` exists and no ``*.tmp.pt`` remain). Exits after
+  ``idle_exit_mins`` with nothing new to do.
+
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+POLL_SECONDS = 300
+FAIL_MARKER = "lm_batch_failed.marker"
+
+
+def _dataset_complete(ds: Path) -> bool:
+    """A dataset is safe to process when preprocessing has finished with it."""
+    if not (ds / "preprocess_meta.json").is_file():
+        return False
+    if any(ds.glob("*.tmp.pt")):
+        return False
+    return any(p for p in ds.glob("*.pt"))
+
+
+def _dataset_variant(ds: Path, fallback: str) -> str:
+    try:
+        meta = json.loads((ds / "preprocess_meta.json").read_text(encoding="utf-8"))
+        return meta.get("model_variant") or fallback
+    except Exception:
+        return fallback
+
+
+def _deployed(deploy_root: Path, name: str, lm_size: str) -> bool:
+    from sidestep_engine.lm.export_lm import sanitize_export_name
+    return (deploy_root / f"{sanitize_export_name(name)}-{lm_size}" / "adapter_model.safetensors").is_file()
+
+
+def find_pending(
+    tensors_root: Path,
+    output_root: Path,
+    deploy_root: Path,
+    lm_size: str,
+) -> List[Path]:
+    """Complete datasets that have no deployed adapter and no failure marker."""
+    pending = []
+    if not tensors_root.is_dir():
+        return pending
+    for ds in sorted(p for p in tensors_root.iterdir() if p.is_dir()):
+        if _deployed(deploy_root, ds.name, lm_size):
+            continue
+        if (output_root / ds.name / FAIL_MARKER).is_file():
+            continue
+        if not _dataset_complete(ds):
+            continue
+        pending.append(ds)
+    return pending
+
+
+def _free_cuda() -> None:
+    import torch
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def run_lm_batch(
+    tensors_root: str,
+    checkpoint_dir: str,
+    output_root: str,
+    model_variant: str = "acestep-v15-merge-base-sft-turbo-xl-thirds",
+    lm_size: str = "4B",
+    rank: int = 16,
+    alpha: int = 32,
+    dropout: float = 0.05,
+    learning_rate: float = 1e-4,
+    epochs: int = 50,
+    grad_accum: int = 2,
+    max_len: int = 8192,
+    loss_on_cot: bool = True,
+    target_loss: float = 0.0,
+    seed: int = 42,
+    device: str = "cuda",
+    precision: str = "bf16",
+    deploy_root: Optional[str] = None,
+    watch: bool = False,
+    idle_exit_mins: int = 120,
+) -> Dict[str, Any]:
+    """Run the batch campaign. Returns a summary dict."""
+    from sidestep_engine.lm.export_lm import export_lm_adapter
+    from sidestep_engine.lm.extract import extract_codes
+    from sidestep_engine.lm.train_lm import load_lm_base, train_lm_adapter
+
+    tensors = Path(tensors_root)
+    out_root = Path(output_root)
+    out_root.mkdir(parents=True, exist_ok=True)
+    deploy = Path(deploy_root) if deploy_root else Path(checkpoint_dir).parent / "adapters" / "lm"
+    batch_log = out_root / "lm_batch_log.jsonl"
+
+    def log_result(name: str, status: str, **extra: Any) -> None:
+        row = {"dataset": name, "status": status, "ts": time.time(), **extra}
+        with batch_log.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row) + "\n")
+
+    done = 0
+    failed = 0
+    idle_since = time.time()
+    t_start = time.time()
+
+    while True:
+        pending = find_pending(tensors, out_root, deploy, lm_size)
+        if not pending:
+            if not watch:
+                break
+            if (time.time() - idle_since) / 60.0 > idle_exit_mins:
+                logger.info("[LM-Batch] Idle for %d min — exiting watch mode", idle_exit_mins)
+                break
+            time.sleep(POLL_SECONDS)
+            continue
+        idle_since = time.time()
+        logger.info("[LM-Batch] Sweep: %d dataset(s) pending", len(pending))
+
+        # ── Burst 1: extraction, ONE shared DiT model ────────────────────────
+        need_extract = [
+            ds for ds in pending
+            if not (out_root / ds.name / "lm_codes.jsonl").is_file()
+        ]
+        if need_extract:
+            from sidestep_engine.models.loader import load_decoder_for_training
+            variant = _dataset_variant(need_extract[0], model_variant)
+            logger.info("[LM-Batch] Extraction burst: %d dataset(s), loading DiT once (%s)",
+                        len(need_extract), variant)
+            dit = load_decoder_for_training(checkpoint_dir, variant, device, precision)
+            try:
+                for ds in need_extract:
+                    out_dir = out_root / ds.name
+                    out_dir.mkdir(parents=True, exist_ok=True)
+                    try:
+                        r = extract_codes(
+                            ds, checkpoint_dir, _dataset_variant(ds, variant),
+                            out_dir / "lm_codes.jsonl",
+                            device=device, precision=precision, model=dit,
+                        )
+                        logger.info("[LM-Batch] Extracted %s: %d songs", ds.name, r["rows"])
+                    except Exception as exc:
+                        failed += 1
+                        (out_dir / FAIL_MARKER).write_text(f"extract: {exc}", encoding="utf-8")
+                        log_result(ds.name, "extract_failed", error=str(exc))
+                        logger.exception("[LM-Batch] EXTRACT FAILED %s", ds.name)
+            finally:
+                del dit
+                _free_cuda()
+
+        # ── Burst 2: training + export, ONE shared base LM ───────────────────
+        trainable = [
+            ds for ds in pending
+            if (out_root / ds.name / "lm_codes.jsonl").is_file()
+        ]
+        if trainable:
+            base, tokenizer = load_lm_base(checkpoint_dir, lm_size, device)
+            try:
+                for i, ds in enumerate(trainable):
+                    out_dir = out_root / ds.name
+                    t0 = time.time()
+                    try:
+                        result = train_lm_adapter(
+                            out_dir / "lm_codes.jsonl", checkpoint_dir, out_dir,
+                            lm_size=lm_size, rank=rank, alpha=alpha, dropout=dropout,
+                            learning_rate=learning_rate, epochs=epochs,
+                            grad_accum=grad_accum, max_len=max_len,
+                            loss_on_cot=loss_on_cot, seed=seed, device=device,
+                            preloaded_model=base, preloaded_tokenizer=tokenizer,
+                            keep_base=True, target_loss=target_loss,
+                        )
+                        exp = export_lm_adapter(
+                            out_dir / "lm_adapter", checkpoint_dir,
+                            lm_size=lm_size, export_name=ds.name, deploy_root=deploy,
+                        )
+                        done += 1
+                        mins = (time.time() - t0) / 60.0
+                        log_result(ds.name, "ok", final_loss=result["final_loss"],
+                                   songs=result["samples"], minutes=round(mins, 1),
+                                   adapter=exp["adapter_name"])
+                        logger.info("[LM-Batch] [%d/%d] %s DONE: loss %.3f, %.1f min -> %s",
+                                    i + 1, len(trainable), ds.name,
+                                    result["final_loss"], mins, exp["adapter_name"])
+                    except Exception as exc:
+                        failed += 1
+                        (out_dir / FAIL_MARKER).write_text(f"train: {exc}", encoding="utf-8")
+                        log_result(ds.name, "train_failed", error=str(exc))
+                        logger.exception("[LM-Batch] TRAIN FAILED %s", ds.name)
+                        # A mid-training failure loses the PEFT wrapper while the
+                        # base's modules are still LoRA-mutated in place — the only
+                        # safe recovery is a fresh base load (~1 min, failure-only).
+                        del base
+                        _free_cuda()
+                        base, tokenizer = load_lm_base(checkpoint_dir, lm_size, device)
+            finally:
+                del base, tokenizer
+                _free_cuda()
+
+        if not watch:
+            break
+
+    hours = (time.time() - t_start) / 3600.0
+    summary = {"done": done, "failed": failed, "hours": round(hours, 2), "log": str(batch_log)}
+    logger.info("[LM-Batch] Campaign summary: %s", summary)
+    return summary

--- a/sidestep_engine/lm/export_lm.py
+++ b/sidestep_engine/lm/export_lm.py
@@ -1,0 +1,124 @@
+"""Merge a trained LM LoRA and export it as a loadable model.
+
+Two export modes:
+
+- ``adapter``: deploy the raw PEFT adapter dir for inference engines
+  with a runtime LM-LoRA path.
+- ``merged``: merge the LoRA into the base LM and save a standard HF
+  safetensors checkpoint dir named ``acestep-5Hz-lm-{size}-{name}``
+  into the models root, where any engine that scans HF checkpoint dirs
+  (Qwen3ForCausalLM ``config.json`` + ``model.safetensors``) picks it
+  up directly.  Optionally convert/quantize to GGUF afterwards with
+  your engine's usual tooling.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+import torch
+
+from sidestep_engine.lm.train_lm import resolve_lm_dir
+
+logger = logging.getLogger(__name__)
+
+
+def sanitize_export_name(name: str) -> str:
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", name.strip()).strip("-._")
+    return name or "custom"
+
+
+def export_lm_adapter(
+    adapter_dir: str | Path,
+    checkpoint_dir: str | Path,
+    lm_size: str = "4B",
+    export_name: str = "custom",
+    deploy_root: str | Path | None = None,
+) -> Dict[str, Any]:
+    """Deploy the raw PEFT adapter for an engine's runtime LM-LoRA path.
+
+    Copies the adapter dir (adapter_model.safetensors + adapter_config.json)
+    into ``<models root>/adapters/lm/<name>-<size>/``.  The engine scans that
+    subtree at startup, lists it in the Planner Adapter dropdown, and applies
+    it at runtime on top of ANY base LM quant — no merge, no 8 GB copies.
+    ``deploy_root`` defaults to ``<checkpoint_dir>/../adapters/lm``.
+    """
+    import shutil
+
+    adapter_dir = Path(adapter_dir)
+    if not (adapter_dir / "adapter_model.safetensors").is_file():
+        raise FileNotFoundError(f"No adapter_model.safetensors in {adapter_dir}")
+    if not (adapter_dir / "adapter_config.json").is_file():
+        raise FileNotFoundError(
+            f"No adapter_config.json in {adapter_dir} — the engine needs it "
+            "for the lora_alpha/r scaling factor"
+        )
+
+    root = Path(deploy_root) if deploy_root else Path(checkpoint_dir).parent / "adapters" / "lm"
+    name = f"{sanitize_export_name(export_name)}-{lm_size}"
+    dest = root / name
+    dest.mkdir(parents=True, exist_ok=True)
+    for f in ("adapter_model.safetensors", "adapter_config.json"):
+        shutil.copy2(adapter_dir / f, dest / f)
+
+    logger.info(
+        "[LM-Export] Adapter deployed -> %s. Restart the inference engine; it "
+        "appears in the Planner Adapter dropdown as '%s' and applies to any "
+        "base %s LM quant at runtime.", dest, name, lm_size,
+    )
+    return {"deploy_dir": str(dest), "adapter_name": name}
+
+
+def merge_and_export(
+    adapter_dir: str | Path,
+    checkpoint_dir: str | Path,
+    lm_size: str = "4B",
+    export_name: str = "custom",
+    models_root: str | Path | None = None,
+    device: str = "cpu",
+) -> Dict[str, Any]:
+    """Merge the LoRA into the base LM and save a loadable HF checkpoint dir.
+
+    Merging runs on CPU by default (bf16, ~2x model size in RAM) so it
+    never competes for VRAM with a running generation or training job.
+    ``models_root`` defaults to *checkpoint_dir* (the models root the
+    inference engine already reads).
+    """
+    from peft import PeftModel
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    adapter_dir = Path(adapter_dir)
+    if not (adapter_dir / "adapter_config.json").is_file():
+        raise FileNotFoundError(f"No adapter_config.json in {adapter_dir}")
+
+    lm_dir = resolve_lm_dir(checkpoint_dir, lm_size)
+    models_root = Path(models_root) if models_root else Path(checkpoint_dir)
+    out_name = f"acestep-5Hz-lm-{lm_size}-{sanitize_export_name(export_name)}"
+    out_dir = models_root / out_name
+
+    logger.info("[LM-Export] Loading base %s on %s ...", lm_dir.name, device)
+    base = AutoModelForCausalLM.from_pretrained(str(lm_dir), torch_dtype=torch.bfloat16)
+    base.to(device)
+    logger.info("[LM-Export] Applying adapter %s ...", adapter_dir)
+    merged = PeftModel.from_pretrained(base, str(adapter_dir))
+    merged = merged.merge_and_unload()
+
+    logger.info("[LM-Export] Saving merged model -> %s", out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    merged.save_pretrained(str(out_dir), safe_serialization=True)
+    tokenizer = AutoTokenizer.from_pretrained(str(lm_dir))
+    tokenizer.save_pretrained(str(out_dir))
+
+    del merged, base
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    logger.info(
+        "[LM-Export] Done. Restart the inference engine and select '%s' in the "
+        "LM model dropdown. (Optional: convert to GGUF + quantize for less "
+        "VRAM — see this module's docstring.)", out_name,
+    )
+    return {"export_dir": str(out_dir), "export_name": out_name}

--- a/sidestep_engine/lm/extract.py
+++ b/sidestep_engine/lm/extract.py
@@ -1,0 +1,166 @@
+"""Extract ground-truth 5Hz audio-code sequences from a preprocessed dataset.
+
+For each final ``.pt`` in the dataset dir, runs the resident FSQ audio
+tokenizer (``model.tokenize``) over the song's real 25Hz latents to get
+the exact 5Hz code sequence the LM would need to emit to "plan" that
+song, and pairs it with the song's caption/lyrics/metas.  Output is one
+JSONL row per song — the SFT dataset for the LM adapter.
+
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import torch
+
+from sidestep_engine.lm.prompts import CODE_FPS_5, LATENT_FPS_25, apply_trigger_tag
+
+logger = logging.getLogger(__name__)
+
+
+def _dataset_tag_position(dataset_dir: Path) -> str:
+    meta_json = dataset_dir / "preprocess_meta.json"
+    if meta_json.is_file():
+        try:
+            return json.loads(meta_json.read_text(encoding="utf-8")).get("tag_position") or "prepend"
+        except Exception:
+            pass
+    return "prepend"
+
+
+def _flatten_indices(indices: torch.Tensor) -> list:
+    """Normalize ResidualFSQ indices to a flat per-frame list of ints.
+
+    Expected shapes: ``[1, T5]`` or ``[1, T5, 1]`` (single quantizer).
+    Multiple quantizers would need an interleaving scheme the engine does
+    not use — refuse loudly rather than corrupt silently.
+    """
+    t = indices
+    if t.dim() == 3:
+        if t.shape[-1] != 1:
+            raise RuntimeError(
+                f"ResidualFSQ returned {t.shape[-1]} quantizers per frame; "
+                "the 5Hz LM vocabulary encodes exactly one code per frame."
+            )
+        t = t.squeeze(-1)
+    if t.dim() != 2 or t.shape[0] != 1:
+        raise RuntimeError(f"Unexpected indices shape {tuple(indices.shape)}")
+    return [int(v) for v in t[0].tolist()]
+
+
+def extract_codes(
+    dataset_dir: str | Path,
+    checkpoint_dir: str | Path,
+    model_variant: str,
+    out_path: str | Path,
+    device: str = "cuda",
+    precision: str = "bf16",
+    progress: Optional[Any] = None,
+    model: Any = None,
+) -> Dict[str, Any]:
+    """Run code extraction over every final ``.pt`` in *dataset_dir*.
+
+    Pass a live ``model`` to reuse an already-loaded
+    ``AceStepConditionGenerationModel`` (e.g. when chained around DiT
+    training); otherwise the full model is loaded and freed here.
+
+    Returns a summary dict: ``{"rows": N, "skipped": M, "out": path}``.
+    """
+    from sidestep_engine.models.loader import load_silence_latent, _resolve_dtype
+
+    dataset_dir = Path(dataset_dir)
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    pt_files = sorted(p for p in dataset_dir.glob("*.pt") if not p.name.endswith(".tmp.pt"))
+    if not pt_files:
+        raise RuntimeError(f"No .pt tensor files found in {dataset_dir}")
+
+    dtype = _resolve_dtype(precision)
+    tag_position = _dataset_tag_position(dataset_dir)
+
+    owns_model = model is None
+    if owns_model:
+        from sidestep_engine.models.loader import load_decoder_for_training
+        logger.info("[LM-Extract] Loading model (%s, %s, %s) ...", model_variant, device, precision)
+        model = load_decoder_for_training(checkpoint_dir, model_variant, device, precision)
+
+    silence = load_silence_latent(checkpoint_dir, device, precision, variant=model_variant)
+
+    rows = 0
+    skipped = 0
+    t0 = time.time()
+    try:
+        with out_path.open("w", encoding="utf-8") as fh:
+            for i, pt in enumerate(pt_files):
+                try:
+                    data = torch.load(str(pt), map_location="cpu", weights_only=False)
+                    meta = dict(data.get("metadata") or {})
+                    lat = data["target_latents"]
+                    del data
+                    if lat.dim() == 2:
+                        lat = lat.unsqueeze(0)
+                    lat = lat.to(device=device, dtype=dtype)
+                    mask = torch.ones(1, lat.shape[1], device=device, dtype=dtype)
+
+                    with torch.no_grad():
+                        _q, indices, _m5 = model.tokenize(lat, silence, mask)
+                    codes = _flatten_indices(indices)
+                    del lat, _q, indices, _m5
+
+                    duration = int(meta.get("duration") or 0)
+                    if duration <= 0:
+                        duration = round(len(codes) / CODE_FPS_5)
+
+                    caption = str(meta.get("caption") or pt.stem)
+                    tagged = apply_trigger_tag(
+                        caption, str(meta.get("custom_tag") or ""), tag_position
+                    )
+                    row = {
+                        "file": pt.name,
+                        "caption": tagged,
+                        "lyrics": str(meta.get("lyrics") or "[Instrumental]"),
+                        "bpm": int(meta.get("bpm") or 0),
+                        "keyscale": str(meta.get("keyscale") or ""),
+                        "timesignature": str(meta.get("timesignature") or ""),
+                        "language": str(meta.get("language") or ""),
+                        "duration": duration,
+                        "codes": codes,
+                    }
+                    fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+                    rows += 1
+                    logger.info(
+                        "[LM-Extract] %d/%d %s -> %d codes (%.0fs audio)",
+                        i + 1, len(pt_files), pt.name, len(codes), len(codes) / CODE_FPS_5,
+                    )
+                    if progress:
+                        progress(i + 1, len(pt_files), pt.name)
+                except Exception:
+                    skipped += 1
+                    logger.exception("[LM-Extract] SKIP %s", pt.name)
+                if device.startswith("cuda") and torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+    finally:
+        if owns_model:
+            del model
+            # torch modules form reference cycles: without an explicit GC pass
+            # the whole DiT stays resident and the 4B LM training then spills
+            # into shared memory. gc BEFORE empty_cache, or the blocks aren't
+            # back in the allocator pool yet.
+            import gc
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    logger.info(
+        "[LM-Extract] Done: %d rows, %d skipped -> %s (%.1fs)",
+        rows, skipped, out_path, time.time() - t0,
+    )
+    if rows == 0:
+        raise RuntimeError("Code extraction produced no rows — see log for per-file errors")
+    return {"rows": rows, "skipped": skipped, "out": str(out_path)}

--- a/sidestep_engine/lm/prompts.py
+++ b/sidestep_engine/lm/prompts.py
@@ -1,0 +1,190 @@
+"""Exact replication of the ACE-Step 5Hz planner LM prompt format.
+
+Every byte here mirrors the inference-side prompt builder — the Phase-2
+prompt whose completion is the audio-code sequence, plus the CoT YAML
+block (byte-verified against a production C++ engine implementation).
+If the inference prompt builder changes, this file must change with it,
+or LM adapters will be trained against a distribution the engine never
+queries (a silent failure mode).
+
+Reference constants (engine/src/prompt.h / task-types.h):
+    TOKEN_IM_START   151644   <|im_start|>
+    TOKEN_IM_END     151645   <|im_end|>
+    TOKEN_THINK      151667   <think>
+    TOKEN_THINK_END  151668   </think>
+    AUDIO_CODE_BASE  151669   <|audio_code_0|>
+    AUDIO_CODE_COUNT 65535
+    LM_INSTRUCTION   "Generate audio semantic tokens based on the given conditions:"
+
+Inference-time sequence layout (Phase 2, conditional branch):
+
+    <|im_start|>system
+    # Instruction
+    Generate audio semantic tokens based on the given conditions:
+
+    <|im_end|>
+    <|im_start|>user
+    # Caption
+    {caption}
+
+    # Lyric
+    {lyrics}
+    <|im_end|>
+    <|im_start|>assistant
+    <think>
+    {cot_yaml}</think>
+
+    {audio code tokens ...}<|im_end|>
+
+The assistant turn is left open after the ``</think>\\n\\n`` — the LM
+generates one ``<|audio_code_N|>`` token per 5Hz frame and terminates
+with ``<|im_end|>``.  Phase-2 decoding is constrained to exactly that
+token set, so training completions are ``codes + <|im_end|>``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+TOKEN_IM_START = 151644
+TOKEN_IM_END = 151645
+TOKEN_THINK = 151667
+TOKEN_THINK_END = 151668
+AUDIO_CODE_BASE = 151669
+AUDIO_CODE_COUNT = 65535
+
+LM_INSTRUCTION = "Generate audio semantic tokens based on the given conditions:"
+
+LATENT_FPS_25 = 25
+CODE_FPS_5 = 5
+
+
+def yaml_wrap(key: str, val: str) -> str:
+    """Port of prompt.h ``yaml_wrap`` (mimics Python yaml.dump wrapping).
+
+    Word-wraps *val* with a line break + 2-space indent whenever the
+    current column exceeds 80.  Byte-exact with the C++.
+    """
+    result = key + ":"
+    col = len(key) + 1
+    i = 0
+    n = len(val)
+    while i < n:
+        end = val.find(" ", i)
+        if end == -1:
+            end = n
+        word = val[i:end]
+        if col > 80:
+            result += "\n  "
+            col = 2
+        else:
+            result += " "
+            col += 1
+        result += word
+        col += len(word)
+        i = end + 1 if end < n else n
+    return result + "\n"
+
+
+def build_cot_yaml(
+    caption: str = "",
+    bpm: int = 0,
+    duration: int = 0,
+    keyscale: str = "",
+    language: str = "",
+    timesignature: str = "",
+) -> str:
+    """Port of prompt.h ``build_cot_yaml`` — keys in sorted order, empties omitted."""
+    yaml = ""
+    if bpm and bpm > 0:
+        yaml += f"bpm: {int(bpm)}\n"
+    if caption:
+        yaml += yaml_wrap("caption", caption)
+    if duration and duration > 0:
+        yaml += f"duration: {int(duration)}\n"
+    if keyscale:
+        yaml += f"keyscale: {keyscale}\n"
+    if language:
+        yaml += f"language: {language}\n"
+    if timesignature:
+        yaml += f"timesignature: {timesignature}\n"
+    return yaml
+
+
+def build_phase2_prompt_text(caption: str, lyrics: str) -> str:
+    """The prompt up to and including ``assistant\\n`` (always loss-masked)."""
+    return (
+        "<|im_start|>system\n# Instruction\n" + LM_INSTRUCTION + "\n\n"
+        + "<|im_end|>\n"
+        + "<|im_start|>user\n# Caption\n" + caption + "\n\n# Lyric\n" + lyrics + "\n"
+        + "<|im_end|>\n"
+        + "<|im_start|>assistant\n"
+    )
+
+
+def build_think_block_text(cot_yaml: str) -> str:
+    """``<think>\\n{yaml}</think>\\n\\n`` — the CoT segment of the assistant turn."""
+    return "<think>\n" + cot_yaml + "</think>\n\n"
+
+
+def build_training_texts(
+    meta: Dict[str, Any],
+    tagged_caption: str,
+    lyrics: str,
+) -> Tuple[str, str]:
+    """Return ``(prompt_text, think_text)`` for one training sample.
+
+    The caller appends audio-code token IDs (``AUDIO_CODE_BASE + idx``)
+    plus ``TOKEN_IM_END`` after tokenizing these strings.
+    """
+    cot = build_cot_yaml(
+        caption=tagged_caption,
+        bpm=int(meta.get("bpm") or 0),
+        duration=int(meta.get("duration") or 0),
+        keyscale=str(meta.get("keyscale") or ""),
+        language=str(meta.get("language") or ""),
+        timesignature=str(meta.get("timesignature") or ""),
+    )
+    return build_phase2_prompt_text(tagged_caption, lyrics), build_think_block_text(cot)
+
+
+def apply_trigger_tag(caption: str, custom_tag: str, tag_position: str = "prepend") -> str:
+    """Mirror of the caption tagging used for DiT training and generation."""
+    tag = (custom_tag or "").strip()
+    if not tag:
+        return caption
+    if tag_position == "append":
+        return f"{caption}, {tag}" if caption else tag
+    if tag_position == "replace":
+        return tag
+    return f"{tag}, {caption}" if caption else tag
+
+
+def codes_to_token_ids(codes: List[int]) -> List[int]:
+    """FSQ indices -> LM vocabulary token IDs, with range validation."""
+    ids = []
+    for c in codes:
+        ci = int(c)
+        if not (0 <= ci < AUDIO_CODE_COUNT):
+            raise ValueError(f"audio code {ci} out of range [0, {AUDIO_CODE_COUNT})")
+        ids.append(AUDIO_CODE_BASE + ci)
+    return ids
+
+
+def verify_tokenizer_atomicity(tokenizer) -> Optional[str]:
+    """Sanity-check that the HF tokenizer maps our special strings to the
+    exact single token IDs the engine uses.  Returns an error string or None.
+    """
+    checks = [
+        ("<|im_start|>", TOKEN_IM_START),
+        ("<|im_end|>", TOKEN_IM_END),
+        ("<think>", TOKEN_THINK),
+        ("</think>", TOKEN_THINK_END),
+        ("<|audio_code_0|>", AUDIO_CODE_BASE),
+        ("<|audio_code_65534|>", AUDIO_CODE_BASE + 65534),
+    ]
+    for text, expected in checks:
+        ids = tokenizer.encode(text, add_special_tokens=False)
+        if ids != [expected]:
+            return f"tokenizer maps {text!r} to {ids}, expected [{expected}]"
+    return None

--- a/sidestep_engine/lm/run.py
+++ b/sidestep_engine/lm/run.py
@@ -1,0 +1,102 @@
+"""Orchestrator for the LM adapter pipeline: extract -> train -> export.
+
+Used by the ``lm-train`` CLI subcommand (standalone) and by the DiT
+training chain hooks (``--lm-train before|after``).
+
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+VALID_LM_SIZES = ("0.6B", "1.7B", "4B")
+
+
+def run_lm_pipeline(
+    dataset_dir: str,
+    checkpoint_dir: str,
+    output_dir: str,
+    model_variant: str = "base",
+    lm_size: str = "4B",
+    rank: int = 16,
+    alpha: int = 32,
+    dropout: float = 0.05,
+    learning_rate: float = 1e-4,
+    epochs: int = 4,
+    grad_accum: int = 4,
+    max_len: int = 8192,
+    loss_on_cot: bool = True,
+    target_loss: float = 0.0,
+    seed: int = 42,
+    device: str = "cuda",
+    precision: str = "bf16",
+    export_name: Optional[str] = None,
+    models_root: Optional[str] = None,
+    stages: str = "all",  # "all" | "extract" | "train" | "export" (comma-combinable)
+    refresh_codes: bool = False,
+    export_mode: str = "adapter",  # "adapter" (runtime LoRA) | "merged" | "both"
+) -> Dict[str, Any]:
+    """Run the requested pipeline stages.  Returns a summary dict.
+
+    The code JSONL is cached at ``{output_dir}/lm_codes.jsonl`` and
+    reused unless *refresh_codes* is set (extraction needs the full DiT
+    model in memory; training/export do not).
+    """
+    if lm_size not in VALID_LM_SIZES:
+        raise ValueError(f"lm_size must be one of {VALID_LM_SIZES} (got {lm_size!r})")
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    jsonl = out / "lm_codes.jsonl"
+    wanted = {s.strip() for s in stages.split(",")} if stages != "all" else {"extract", "train", "export"}
+    summary: Dict[str, Any] = {"jsonl": str(jsonl)}
+
+    if "extract" in wanted and (refresh_codes or not jsonl.is_file()):
+        from sidestep_engine.lm.extract import extract_codes
+        logger.info("[LM] Stage 1/3: extracting audio codes from %s", dataset_dir)
+        summary["extract"] = extract_codes(
+            dataset_dir, checkpoint_dir, model_variant, jsonl,
+            device=device, precision=precision,
+        )
+    elif jsonl.is_file():
+        logger.info("[LM] Stage 1/3: reusing cached codes %s (--lm-refresh-codes to redo)", jsonl)
+    elif "train" in wanted:
+        raise RuntimeError(f"No code JSONL at {jsonl} and extract stage not requested")
+
+    if "train" in wanted:
+        from sidestep_engine.lm.train_lm import train_lm_adapter
+        logger.info("[LM] Stage 2/3: training %s LoRA (r=%d) ...", lm_size, rank)
+        summary["train"] = train_lm_adapter(
+            jsonl, checkpoint_dir, out, lm_size=lm_size, rank=rank, alpha=alpha,
+            dropout=dropout, learning_rate=learning_rate, epochs=epochs,
+            grad_accum=grad_accum, max_len=max_len, loss_on_cot=loss_on_cot,
+            seed=seed, device=device, target_loss=target_loss,
+        )
+
+    if "export" in wanted:
+        adapter_dir = out / "lm_adapter"
+        name = export_name or out.name
+        if export_mode not in ("adapter", "merged", "both"):
+            raise ValueError(f"export_mode must be adapter|merged|both (got {export_mode!r})")
+        if export_mode in ("adapter", "both"):
+            from sidestep_engine.lm.export_lm import export_lm_adapter
+            logger.info("[LM] Stage 3/3: deploying runtime adapter as %s ...", name)
+            summary["export"] = export_lm_adapter(
+                adapter_dir, checkpoint_dir, lm_size=lm_size, export_name=name,
+                deploy_root=models_root if export_mode == "adapter" and models_root else None,
+            )
+        if export_mode in ("merged", "both"):
+            from sidestep_engine.lm.export_lm import merge_and_export
+            logger.info("[LM] Stage 3/3%s: merging + exporting as %s ...",
+                        "b" if export_mode == "both" else "", name)
+            summary["export_merged"] = merge_and_export(
+                adapter_dir, checkpoint_dir, lm_size=lm_size, export_name=name,
+                models_root=models_root if export_mode != "both" else None, device="cpu",
+            )
+
+    logger.info("[LM] Pipeline complete: %s", {k: v for k, v in summary.items() if k != "jsonl"})
+    return summary

--- a/sidestep_engine/lm/train_lm.py
+++ b/sidestep_engine/lm/train_lm.py
@@ -1,0 +1,359 @@
+"""LoRA SFT trainer for the ACE-Step 5Hz planner LM.
+
+Standard causal-LM supervised fine-tuning with PEFT LoRA:
+
+- Base: ``acestep-5Hz-lm-{size}`` (Qwen3ForCausalLM, HF checkpoint dir
+  inside the models root, which doubles as Side-Step's
+  checkpoint_dir).
+- Samples: prompt (masked) + optional CoT block + audio-code tokens +
+  ``<|im_end|>`` (trained), built byte-exactly like the engine's prompt
+  builder (see prompts.py).
+- Loss on completion only.  ``loss_on_cot=True`` (default) also trains
+  the CoT metas block so the adapter learns artist-typical bpm/keys for
+  Phase-1 planning.
+
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import random
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+import torch
+
+from sidestep_engine.lm.prompts import (
+    TOKEN_IM_END,
+    build_training_texts,
+    codes_to_token_ids,
+    verify_tokenizer_atomicity,
+)
+
+logger = logging.getLogger(__name__)
+
+LM_DIR_TEMPLATE = "acestep-5Hz-lm-{size}"
+DEFAULT_TARGET_MODULES = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+
+
+def resolve_lm_dir(checkpoint_dir: str | Path, lm_size: str) -> Path:
+    lm_dir = Path(checkpoint_dir) / LM_DIR_TEMPLATE.format(size=lm_size)
+    if not (lm_dir / "config.json").is_file():
+        raise FileNotFoundError(
+            f"LM checkpoint not found: {lm_dir} (need the HF safetensors dir, "
+            f"e.g. <models root>/acestep-5Hz-lm-{lm_size})"
+        )
+    return lm_dir
+
+
+def load_lm_base(checkpoint_dir: str | Path, lm_size: str = "4B", device: str = "cuda"):
+    """Load the base LM + tokenizer once for reuse across batch trainings.
+
+    Pass the result to :func:`train_lm_adapter` via ``preloaded_model``/
+    ``preloaded_tokenizer`` with ``keep_base=True``.
+    """
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    lm_dir = resolve_lm_dir(checkpoint_dir, lm_size)
+    logger.info("[LM-Train] Loading shared base LM: %s", lm_dir)
+    tokenizer = AutoTokenizer.from_pretrained(str(lm_dir))
+    model = AutoModelForCausalLM.from_pretrained(
+        str(lm_dir), torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    model.to(device)
+    return model, tokenizer
+
+
+def _build_samples(
+    jsonl_path: Path,
+    tokenizer,
+    loss_on_cot: bool,
+    max_len: int,
+) -> List[Dict[str, Any]]:
+    samples = []
+    skipped_long = 0
+    with jsonl_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            prompt_text, think_text = build_training_texts(row, row["caption"], row["lyrics"])
+            prompt_ids = tokenizer.encode(prompt_text, add_special_tokens=False)
+            think_ids = tokenizer.encode(think_text, add_special_tokens=False)
+            code_ids = codes_to_token_ids(row["codes"])
+
+            if loss_on_cot:
+                masked = prompt_ids
+                trained = think_ids + code_ids + [TOKEN_IM_END]
+            else:
+                masked = prompt_ids + think_ids
+                trained = code_ids + [TOKEN_IM_END]
+
+            total = len(masked) + len(trained)
+            if total > max_len:
+                skipped_long += 1
+                logger.warning(
+                    "[LM-Train] SKIP %s: %d tokens > max_len %d (raise --lm-max-len "
+                    "or shorten the song)", row.get("file"), total, max_len,
+                )
+                continue
+            samples.append({
+                "file": row.get("file", "?"),
+                "input_ids": masked + trained,
+                "n_masked": len(masked),
+            })
+    if not samples:
+        raise RuntimeError(
+            f"No usable training samples from {jsonl_path} "
+            f"({skipped_long} skipped as over-length)"
+        )
+    logger.info(
+        "[LM-Train] %d samples (%d skipped over-length), lengths %d..%d tokens",
+        len(samples), skipped_long,
+        min(len(s["input_ids"]) for s in samples),
+        max(len(s["input_ids"]) for s in samples),
+    )
+    return samples
+
+
+def _forward_backward_chunked(
+    model: Any,
+    input_ids: torch.Tensor,
+    labels: torch.Tensor,
+    grad_accum: int,
+    chunk_size: int = 512,
+) -> float:
+    """Memory-efficient causal-LM loss + backward for a huge vocabulary.
+
+    The 5Hz LM's vocab is ~217k tokens, so full-sequence fp32 logits are
+    multiple GB and the stock ``labels=`` loss path materializes several
+    copies — that blows past VRAM on whole-song sequences.  Instead:
+    run the trunk once, then per ~chunk_size positions compute
+    lm_head + cross-entropy against a DETACHED hidden copy and backward
+    immediately (peak extra memory = one chunk of logits), finally
+    backward the trunk once with the accumulated hidden-state gradient.
+    Mathematically identical to the stock loss; lm_head is frozen so the
+    per-chunk backwards only produce hidden grads.
+
+    Returns the mean CE over trained tokens (unscaled by grad_accum).
+    """
+    import torch.nn.functional as F
+
+    base = model.get_base_model()  # PEFT -> Qwen3ForCausalLM (.model + .lm_head)
+    h = base.model(input_ids=input_ids).last_hidden_state  # [1, S, H]
+    hd = h.detach().requires_grad_(True)
+
+    S = input_ids.shape[1]
+    n_tok = int((labels[:, 1:] != -100).sum().item())
+    if n_tok == 0:
+        return 0.0
+
+    total = 0.0
+    for i in range(0, S - 1, chunk_size):
+        j = min(i + chunk_size, S - 1)  # positions [i, j) predict labels [i+1, j+1)
+        tgt = labels[:, i + 1 : j + 1]
+        if not bool((tgt != -100).any()):
+            continue  # fully-masked (prompt) chunk: no loss, no grad
+        logits = base.lm_head(hd[:, i:j]).float()
+        loss = F.cross_entropy(
+            logits.reshape(-1, logits.shape[-1]), tgt.reshape(-1),
+            ignore_index=-100, reduction="sum",
+        )
+        (loss / (n_tok * grad_accum)).backward()
+        total += float(loss.item())
+        del logits, loss
+
+    if hd.grad is not None:
+        h.backward(gradient=hd.grad)
+    return total / n_tok
+
+
+def train_lm_adapter(
+    jsonl_path: str | Path,
+    checkpoint_dir: str | Path,
+    output_dir: str | Path,
+    lm_size: str = "4B",
+    rank: int = 16,
+    alpha: int = 32,
+    dropout: float = 0.05,
+    learning_rate: float = 1e-4,
+    epochs: int = 4,
+    grad_accum: int = 4,
+    max_len: int = 8192,
+    loss_on_cot: bool = True,
+    seed: int = 42,
+    device: str = "cuda",
+    warmup_ratio: float = 0.05,
+    progress: Any = None,
+    preloaded_model: Any = None,
+    preloaded_tokenizer: Any = None,
+    keep_base: bool = False,
+    target_loss: float = 0.0,
+) -> Dict[str, Any]:
+    """Train the LoRA adapter.  Returns ``{"adapter_dir", "final_loss", ...}``.
+
+    Batch size is 1 sequence with ``grad_accum`` accumulation — sequence
+    lengths vary per song, and at 4B with gradient checkpointing this is
+    the VRAM-safe shape.
+
+    Batch mode: pass ``preloaded_model``/``preloaded_tokenizer`` (from
+    :func:`load_lm_base`) and ``keep_base=True`` to reuse one resident base
+    LM across many adapter trainings — the PEFT wrapper is unloaded at the
+    end, restoring the caller's base model in place.
+    """
+    from peft import LoraConfig, get_peft_model
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    jsonl_path = Path(jsonl_path)
+    output_dir = Path(output_dir)
+    adapter_dir = output_dir / "lm_adapter"
+    adapter_dir.mkdir(parents=True, exist_ok=True)
+
+    if preloaded_tokenizer is not None:
+        tokenizer = preloaded_tokenizer
+    else:
+        lm_dir = resolve_lm_dir(checkpoint_dir, lm_size)
+        logger.info("[LM-Train] Base LM: %s", lm_dir)
+        tokenizer = AutoTokenizer.from_pretrained(str(lm_dir))
+    atomicity_err = verify_tokenizer_atomicity(tokenizer)
+    if atomicity_err:
+        raise RuntimeError(f"Tokenizer/prompt mismatch vs engine: {atomicity_err}")
+
+    samples = _build_samples(jsonl_path, tokenizer, loss_on_cot, max_len)
+
+    # Defensive: reclaim anything a prior pipeline stage (code extraction's
+    # full DiT model) left behind before loading the 4B LM.
+    import gc
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    if preloaded_model is not None:
+        model = preloaded_model
+    else:
+        model = AutoModelForCausalLM.from_pretrained(
+            str(resolve_lm_dir(checkpoint_dir, lm_size)),
+            torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+        )
+        model.to(device)
+    model.config.use_cache = False
+    model.gradient_checkpointing_enable()
+    model.enable_input_require_grads()
+
+    lora_cfg = LoraConfig(
+        r=rank, lora_alpha=alpha, lora_dropout=dropout,
+        target_modules=DEFAULT_TARGET_MODULES, bias="none", task_type="CAUSAL_LM",
+    )
+    model = get_peft_model(model, lora_cfg)
+    # fp32 adapter weights for optimizer stability (PEFT casts activations)
+    for p in model.parameters():
+        if p.requires_grad:
+            p.data = p.data.to(torch.float32)
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    logger.info("[LM-Train] LoRA r=%d alpha=%d dropout=%.2f -> %.1fM trainable params",
+                rank, alpha, dropout, trainable / 1e6)
+
+    params = [p for p in model.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(params, lr=learning_rate, weight_decay=0.01)
+
+    steps_per_epoch = math.ceil(len(samples) / grad_accum)
+    total_steps = max(1, steps_per_epoch * epochs)
+    warmup_steps = max(1, int(total_steps * warmup_ratio))
+
+    def lr_lambda(step: int) -> float:
+        if step < warmup_steps:
+            return step / warmup_steps
+        p = (step - warmup_steps) / max(1, total_steps - warmup_steps)
+        return 0.1 + 0.9 * 0.5 * (1.0 + math.cos(math.pi * p))
+
+    scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+
+    rng = random.Random(seed)
+    torch.manual_seed(seed)
+
+    model.train()
+    global_step = 0
+    epoch_losses: List[float] = []
+    t0 = time.time()
+    log: Dict[str, Any] = {"epochs": [], "config": {
+        "lm_size": lm_size, "rank": rank, "alpha": alpha, "dropout": dropout,
+        "lr": learning_rate, "epochs": epochs, "grad_accum": grad_accum,
+        "loss_on_cot": loss_on_cot, "seed": seed, "samples": len(samples),
+        "target_loss": target_loss,
+    }}
+
+    for epoch in range(epochs):
+        order = list(range(len(samples)))
+        rng.shuffle(order)
+        running = 0.0
+        n_micro = 0
+        optimizer.zero_grad(set_to_none=True)
+        for j, idx in enumerate(order):
+            s = samples[idx]
+            input_ids = torch.tensor([s["input_ids"]], dtype=torch.long, device=device)
+            labels = input_ids.clone()
+            labels[0, : s["n_masked"]] = -100
+
+            # Chunked loss+backward: never materializes full [S, 217k] logits
+            sample_loss = _forward_backward_chunked(model, input_ids, labels, grad_accum)
+            running += sample_loss
+            n_micro += 1
+
+            if (j + 1) % grad_accum == 0 or (j + 1) == len(order):
+                torch.nn.utils.clip_grad_norm_(params, 1.0)
+                optimizer.step()
+                scheduler.step()
+                optimizer.zero_grad(set_to_none=True)
+                global_step += 1
+
+            del input_ids, labels
+
+        avg = running / max(1, n_micro)
+        epoch_losses.append(avg)
+        lr_now = scheduler.get_last_lr()[0]
+        logger.info("[LM-Train] Epoch %d/%d  loss=%.4f  lr=%.2e  (%.0fs elapsed)",
+                    epoch + 1, epochs, avg, lr_now, time.time() - t0)
+        if progress:
+            progress(epoch + 1, epochs, avg)
+        log["epochs"].append({"epoch": epoch + 1, "loss": avg, "lr": lr_now})
+
+        model.save_pretrained(str(adapter_dir))
+        if device.startswith("cuda") and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        # Loss-target stop: fixed epoch counts overtrain large datasets
+        # (steps/epoch scales with song count; measured r=-0.74 between song
+        # count and final CE). The target normalizes FIT level across dataset
+        # sizes — `epochs` is just the safety cap.
+        if target_loss > 0 and avg <= target_loss:
+            logger.info("[LM-Train] Target loss reached: %.4f <= %.2f at epoch %d/%d — stopping",
+                        avg, target_loss, epoch + 1, epochs)
+            log["target_loss_stop"] = {"epoch": epoch + 1, "loss": avg}
+            break
+
+    (output_dir / "lm_train_log.json").write_text(
+        json.dumps(log, indent=2), encoding="utf-8"
+    )
+    if keep_base:
+        # Restore the caller's resident base LM in place: unload() strips the
+        # LoRA modules and returns the original (mutated-back) base model, so
+        # the next dataset in a batch can re-wrap it without a 4B reload.
+        model.unload()
+        del model, optimizer, params
+    else:
+        del model, optimizer, params
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    logger.info("[LM-Train] Done: adapter -> %s (final loss %.4f)", adapter_dir, epoch_losses[-1])
+    return {
+        "adapter_dir": str(adapter_dir),
+        "final_loss": epoch_losses[-1],
+        "epoch_losses": epoch_losses,
+        "samples": len(samples),
+    }

--- a/train.py
+++ b/train.py
@@ -122,6 +122,7 @@ def _apply_deprecation_shim() -> None:
 _KNOWN_SUBCOMMANDS = {
     "train", "preprocess", "analyze", "audio-analyze", "dataset",
     "captions", "tags", "settings", "history", "export", "gui",
+    "lm-train", "lm-batch",
 }
 
 
@@ -268,9 +269,9 @@ def _dispatch(args) -> int:
     _auto_resolve_shift_steps(args)
 
     # -- Validate required fields (relaxed from argparse for --config/--preprocess)
-    if sub in ("train", "analyze"):
+    if sub in ("train", "analyze", "lm-train"):
         required = [("checkpoint_dir", "--checkpoint-dir / -c"), ("dataset_dir", "--dataset-dir / -d")]
-        if sub == "train":
+        if sub in ("train", "lm-train"):
             required.append(("output_dir", "--output-dir / -o"))
         if not _validate_required_args(args, required):
             return 1
@@ -282,6 +283,12 @@ def _dispatch(args) -> int:
     if sub == "train":
         from sidestep_engine.cli.train_fixed import run_fixed
         return run_fixed(args)
+
+    elif sub == "lm-train":
+        return _run_lm_train(args)
+
+    elif sub == "lm-batch":
+        return _run_lm_batch(args)
 
     elif sub == "analyze":
         return _run_fisher(args)
@@ -526,6 +533,110 @@ def _run_preprocess_subcommand(args) -> int:
     print(f"\n[INFO] You can now train with:")
     print(f"       sidestep train -d {result['output_dir']} ...")
     return 0
+
+
+def _lm_params_from_args(args) -> dict:
+    """Collect shared --lm-* args into run_lm_pipeline kwargs."""
+    import torch as _torch
+    device = getattr(args, "device", "auto") or "auto"
+    if device == "auto":
+        device = "cuda" if _torch.cuda.is_available() else "cpu"
+    precision = getattr(args, "precision", "auto") or "auto"
+    if precision == "auto":
+        precision = "bf16" if device.startswith("cuda") else "fp32"
+    return {
+        "dataset_dir": getattr(args, "dataset_dir", None),
+        "checkpoint_dir": getattr(args, "checkpoint_dir", None),
+        "model_variant": getattr(args, "model_variant", "base"),
+        "lm_size": getattr(args, "lm_size", "4B"),
+        "rank": getattr(args, "lm_rank", 16),
+        "alpha": getattr(args, "lm_alpha", 32),
+        "dropout": getattr(args, "lm_dropout", 0.05),
+        "learning_rate": getattr(args, "lm_lr", 1e-4),
+        "epochs": getattr(args, "lm_epochs", 4),
+        "grad_accum": getattr(args, "lm_grad_accum", 4),
+        "max_len": getattr(args, "lm_max_len", 8192),
+        "loss_on_cot": getattr(args, "lm_loss_on_cot", True),
+        "target_loss": getattr(args, "lm_target_loss", 0.0),
+        "seed": getattr(args, "lm_seed", 42),
+        "device": device,
+        "precision": precision,
+        "export_name": getattr(args, "lm_export_name", None),
+        "models_root": getattr(args, "lm_models_root", None),
+        "refresh_codes": getattr(args, "lm_refresh_codes", False),
+        "export_mode": getattr(args, "lm_export_mode", "adapter"),
+    }
+
+
+def _run_lm_train(args) -> int:
+    """Standalone 5Hz planner LM adapter training."""
+    from sidestep_engine.lm.run import run_lm_pipeline
+
+    print("\n" + "=" * 60)
+    print("  Planner LM adapter training (5Hz LM)")
+    print("=" * 60)
+    print(f"  Checkpoint root: {args.checkpoint_dir}")
+    print(f"  Dataset:         {args.dataset_dir}")
+    print(f"  Output:          {args.output_dir}")
+    print(f"  LM size:         {getattr(args, 'lm_size', '4B')}")
+    print("=" * 60)
+
+    try:
+        params = _lm_params_from_args(args)
+        params["output_dir"] = args.output_dir
+        params["stages"] = getattr(args, "lm_stages", "all")
+        run_lm_pipeline(**params)
+        return 0
+    except KeyboardInterrupt:
+        print("[WARN] LM training interrupted by user", file=sys.stderr)
+        return 130
+    except Exception as exc:
+        import traceback
+        traceback.print_exc()
+        print(f"[FAIL] LM adapter training failed: {exc}", file=sys.stderr)
+        return 1
+
+
+def _run_lm_batch(args) -> int:
+    """Batch planner-LM adapters across all preprocessed datasets."""
+    from sidestep_engine.lm.batch import run_lm_batch
+
+    p = _lm_params_from_args(args)
+    print("\n" + "=" * 60)
+    print("  Planner LM adapter BATCH campaign")
+    print("=" * 60)
+    print(f"  Tensors root:    {args.tensors_root}")
+    print(f"  Output root:     {args.output_root}")
+    print(f"  LM size/epochs:  {p['lm_size']} / {p['epochs']}")
+    print(f"  Watch mode:      {getattr(args, 'watch', False)}")
+    print("=" * 60)
+
+    try:
+        summary = run_lm_batch(
+            tensors_root=args.tensors_root,
+            checkpoint_dir=args.checkpoint_dir,
+            output_root=args.output_root,
+            model_variant=p["model_variant"],
+            lm_size=p["lm_size"], rank=p["rank"], alpha=p["alpha"],
+            dropout=p["dropout"], learning_rate=p["learning_rate"],
+            epochs=p["epochs"], grad_accum=p["grad_accum"], max_len=p["max_len"],
+            loss_on_cot=p["loss_on_cot"], target_loss=p["target_loss"], seed=p["seed"],
+            device=p["device"], precision=p["precision"],
+            deploy_root=p["models_root"],
+            watch=getattr(args, "watch", False),
+            idle_exit_mins=getattr(args, "idle_exit_mins", 120),
+        )
+        print(f"[OK] Batch campaign finished: {summary['done']} trained, "
+              f"{summary['failed']} failed, {summary['hours']}h — log: {summary['log']}")
+        return 0 if summary["failed"] == 0 else 3
+    except KeyboardInterrupt:
+        print("[WARN] Batch interrupted — safe to relaunch, it resumes where it left off", file=sys.stderr)
+        return 130
+    except Exception as exc:
+        import traceback
+        traceback.print_exc()
+        print(f"[FAIL] LM batch failed: {exc}", file=sys.stderr)
+        return 1
 
 
 def _run_fisher(args) -> int:


### PR DESCRIPTION
# Planner-LM adapter training: lm-train, lm-batch, --lm-train chaining

ACE-Step 1.5 generation is a two-model system: the 5Hz planner LM writes the audio-code sequence, then the DiT renders it. Side-Step trains DiT adapters — but for artists whose identity lives in *structure* (song form, phrasing, vocal placement, typical bpm/keys), a DiT LoRA alone can't capture it. This adds the other half: LoRA adapters for the `acestep-5Hz-lm-*` planner (Qwen3 bases, 0.6B/1.7B/4B).

**`lm-train`** — a three-stage pipeline over the same preprocessed dataset dirs used for DiT training:
1. *extract*: dataset songs → code-sequence JSONL (cached; `--lm-refresh-codes` to redo)
2. *train*: PEFT LoRA SFT, prompt tokens masked, loss on the audio-code completion; `--lm-loss-on-cot` (default on) also trains the CoT metas block so the adapter learns artist-typical bpm/keys; `--lm-target-loss` stops at a mean CE/token target so fit is normalized across dataset sizes (`--lm-epochs` becomes a safety cap)
3. *export*: raw PEFT adapter dir (for engines with a runtime LM-LoRA path) and/or a merged HF safetensors checkpoint named `acestep-5Hz-lm-{size}-{name}` — standard format, loadable by anything that scans HF checkpoint dirs

**`lm-batch`** — resumable multi-dataset campaign (one adapter per artist dataset) with `--watch` mode that picks up datasets as a concurrent preprocessing job completes them.

**`train --lm-train before|after`** — chains an LM adapter run around a DiT run in a subprocess, guaranteeing a clean VRAM lifecycle on both sides.

The correctness-critical piece is `lm/prompts.py`: prompt construction byte-mirrors the inference-side Phase-2 prompt + CoT YAML (verified against a production C++ engine implementation of the 5Hz LM prompt builder). Training against even a slightly different prompt distribution silently produces adapters the engine never actually exercises.

Self-contained: no changes to existing training paths; heavy deps import only inside the new subcommands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
