### PR TITLE
Training control: pause/resume, persistent queue, resume-display fixes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -381,6 +381,22 @@
               <button class="btn btn--sm btn--refresh" title="Refresh dataset list">R</button>
             </div>
             <div class="detect" id="full-dataset-detect"></div>
+            <div id="full-dataset-multi" style="display:none; margin-top:var(--space-sm); max-height:240px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius); padding:var(--space-sm);">
+              <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--space-xs);">
+                <span style="font-size:var(--font-size-sm); color:var(--muted);">Select datasets to queue:</span>
+                <span style="display:flex; gap:var(--space-xs);">
+                  <button class="btn btn--sm" id="btn-batch-select-all" title="Select all">All</button>
+                  <button class="btn btn--sm" id="btn-batch-select-none" title="Deselect all">None</button>
+                </span>
+              </div>
+              <div id="full-dataset-multi-list"></div>
+            </div>
+            <div style="margin-top:var(--space-xs);">
+              <label style="display:flex; align-items:center; gap:var(--space-xs); cursor:pointer; font-size:var(--font-size-sm); color:var(--muted);">
+                <input type="checkbox" id="full-batch-mode">
+                Batch mode — select multiple datasets to queue
+              </label>
+            </div>
             <div id="help-full-dataset" class="help-panel">
               <p>Datasets found in your configured tensors and audio directories.</p>
               <p><em>Can't find your dataset? Check Settings.</em></p>
@@ -393,6 +409,12 @@
             <div id="help-full-run-name" class="help-panel">
               <p><strong>Simple:</strong> A human-readable name for this training run. Used in file paths, logs, and the History tab to identify your experiment.</p>
               <p>Auto-generated from adapter type + model variant. A timestamp is appended when training starts to prevent overwriting previous runs.</p>
+            </div>
+            <div style="display:flex; align-items:center; gap:var(--space-sm); margin-top:var(--space-xs);">
+              <label style="display:flex; align-items:center; gap:var(--space-xs); cursor:pointer; font-size:var(--font-size-sm); color:var(--muted);">
+                <input type="checkbox" id="full-auto-name-dataset">
+                Use dataset name as run name
+              </label>
             </div>
             <div class="hint">Auto-generated from adapter + model. Timestamp added at start.</div>
           </div>
@@ -1474,6 +1496,7 @@
             <div style="margin-top: var(--space-lg); display: flex; flex-direction: column; align-items: center; gap: var(--space-xs);">
               <div style="display:flex; gap:var(--space-sm);">
                 <button class="btn btn--success" id="btn-start-full">Start Training</button>
+                <button class="btn btn--success" id="btn-queue-selected" style="display:none;">Queue Selected</button>
                 <button class="btn btn--sm" id="btn-export-cli" title="Copy CLI command to clipboard">Export CLI</button>
               </div>
               <div id="full-queue-status" style="display:none;font-size:var(--font-size-sm);margin-top:var(--space-xs);color:var(--muted);text-align:center;"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1700,10 +1700,11 @@
           <div>
             <!-- Controls (toggled, never destroyed) -->
             <div id="monitor-controls" style="display: flex; gap: var(--space-md); margin-bottom: var(--space-lg);">
+              <button class="btn btn--warning" id="btn-pause">&#x23F8; Pause</button>
               <button class="btn btn--danger" id="btn-stop">Stop Training</button>
               <button class="btn btn--danger" id="btn-stop-all" style="display:none;">Stop All</button>
               <button class="btn" id="btn-open-output">Open Output Dir</button>
-              <span style="color: var(--muted); font-size: var(--font-size-sm); align-self: center;">Stop skips current run. Stop All cancels the queue.</span>
+              <span style="color: var(--muted); font-size: var(--font-size-sm); align-self: center;">Pause saves &amp; frees VRAM. Stop skips current run. Stop All cancels the queue.</span>
             </div>
 
             <!-- Completion banner (shown after training ends, hidden on new run) -->

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -145,6 +145,7 @@ const API = (() => {
 
   async function startTraining(config) { return _post('/api/train/start', { config }); }
   async function stopTraining() { return _post('/api/train/stop', {}); }
+  async function pauseTraining() { return _post('/api/train/pause', {}); }
 
   // ---- Dataset Scanning -------------------------------------------------
 
@@ -391,6 +392,7 @@ const API = (() => {
     deleteHistoryFolder,
     startTraining,
     stopTraining,
+    pauseTraining,
     browseDir,
     scanTensorsDir,
     scanAudioFolder,

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -147,6 +147,11 @@ const API = (() => {
   async function stopTraining() { return _post('/api/train/stop', {}); }
   async function pauseTraining() { return _post('/api/train/pause', {}); }
 
+  // ---- Persistent Training Queue ----------------------------------------
+
+  async function loadTrainingQueue() { return _get('/api/train/queue'); }
+  async function saveTrainingQueue(data) { return _post('/api/train/queue', data); }
+
   // ---- Dataset Scanning -------------------------------------------------
 
   async function scanTensorsDir(tensorsDir) { return _get('/api/datasets?tensors_dir=' + encodeURIComponent(tensorsDir || '')); }
@@ -393,6 +398,8 @@ const API = (() => {
     startTraining,
     stopTraining,
     pauseTraining,
+    loadTrainingQueue,
+    saveTrainingQueue,
     browseDir,
     scanTensorsDir,
     scanAudioFolder,

--- a/frontend/js/training-chart.js
+++ b/frontend/js/training-chart.js
@@ -135,10 +135,11 @@ const TrainingChart = (() => {
 
   /**
    * Render the loss/LR chart SVG.
-   * @param {Object} opts - { fullLoss, fullLr, viewXMin, viewXMax, smoothingWeight }
+   * @param {Object} opts - { fullLoss, fullLr, viewXMin, viewXMax, smoothingWeight, xOffset }
    */
   function render(opts) {
-    let { fullLoss, fullLr, viewXMin, viewXMax, smoothingWeight } = opts;
+    let { fullLoss, fullLr, viewXMin, viewXMax, smoothingWeight, xOffset } = opts;
+    const xOff = xOffset || 0;  // offset for resumed training X-axis labels
     if (fullLoss.length < 1) return;
     // SVG polyline with a single point is invisible. Duplicate so callers that
     // pass exactly one sample (e.g. first step before epoch completes) still
@@ -214,11 +215,11 @@ const TrainingChart = (() => {
       });
       // Vertical grid lines (TB X_GRID_COUNT = 10)
       const width = svg.getBoundingClientRect().width || 400;
-      const loTick = Math.max(0, startIdx);
-      const hiTick = Math.max(loTick + 1, endIdx - 1);
+      const loTick = Math.max(0, startIdx + xOff);
+      const hiTick = Math.max(loTick + 1, endIdx - 1 + xOff);
       const vTicks = _buildXTicks(loTick, hiTick, width);
       vTicks.forEach(tick => {
-        const frac = (tick - startIdx) / Math.max(1, endIdx - startIdx - 1);
+        const frac = (tick - startIdx - xOff) / Math.max(1, endIdx - startIdx - 1);
         if (frac < 0 || frac > 1) return;
         const x = (frac * vbW).toFixed(1);
         gridHTML += `<line x1="${x}" y1="0" x2="${x}" y2="${vbH}" stroke="rgba(255,255,255,0.08)" stroke-width="1" vector-effect="non-scaling-stroke" />`;
@@ -245,11 +246,11 @@ const TrainingChart = (() => {
       // TensorBoard-style axis behavior: choose tick count by available pixels,
       // then place each label at its true fractional position in view.
       const width = svg.getBoundingClientRect().width || 400;
-      const loTick = Math.max(0, startIdx);
-      const hiTick = Math.max(loTick + 1, endIdx - 1);
+      const loTick = Math.max(0, startIdx + xOff);
+      const hiTick = Math.max(loTick + 1, endIdx - 1 + xOff);
       const ticks = _buildXTicks(loTick, hiTick, width);
       xLabelsEl.innerHTML = ticks.map((tick) => {
-        const left = ((tick - startIdx) / Math.max(1, endIdx - startIdx - 1)) * 100;
+        const left = ((tick - startIdx - xOff) / Math.max(1, endIdx - startIdx - 1)) * 100;
         return `<span class="axis-label-row__tick" style="left:${left.toFixed(3)}%;">${tick.toLocaleString()}</span>`;
       }).join('');
     }

--- a/frontend/js/training.js
+++ b/frontend/js/training.js
@@ -9,6 +9,7 @@ const Training = (() => {
   let _queue = [];  // { id, config, status: 'pending'|'running'|'done'|'failed'|'stopped' }
   let _queueIdCounter = 0;
   let _step = 0, _epoch = 0, _maxEpochs = 100, _stepsPerEpoch = 0, _stepInEpoch = 0;
+  let _resumeStartEpoch = 0, _resumeStartStep = 0;  // non-zero when resuming from checkpoint
   let _loss = 0, _bestLoss = Infinity, _bestEpoch = 0, _lr = 0;
   let _lossHistory = [], _lrHistory = [];
   let _epochLossHistory = [], _epochLrHistory = [];
@@ -126,12 +127,13 @@ const Training = (() => {
     const ma5 = _calcMA(5);
     setText('monitor-ma5', ma5 !== null ? ma5.toFixed(4) : '--');
 
-    // Timing
+    // Timing — use session-relative steps for accurate speed/ETA on resumed runs
     const elapsed = (Date.now() - _startTime) / 1000;
+    const sessionSteps = Math.max(0, _step - _resumeStartStep);
     setText('monitor-elapsed', _fmtDuration(elapsed));
-    setText('monitor-step-time', _step > 0 ? (elapsed / _step).toFixed(2) + 's' : '--');
+    setText('monitor-step-time', sessionSteps > 0 ? (elapsed / sessionSteps).toFixed(2) + 's' : '--');
     setText('monitor-epoch-time', _lastEpochDuration > 0 ? _lastEpochDuration.toFixed(1) + 's' : '--');
-    setText('monitor-sps', _step > 0 ? ((_step / elapsed) || 0).toFixed(1) + ' steps/s' : '--');
+    setText('monitor-sps', sessionSteps > 0 ? ((sessionSteps / elapsed) || 0).toFixed(1) + ' steps/s' : '--');
 
     // ETA
     const remainingEpochs = _maxEpochs - _epoch;
@@ -178,7 +180,9 @@ const Training = (() => {
   function _updateLossChart() {
     const { loss, lr } = _getChartData();
     if (typeof TrainingChart !== "undefined") {
-      TrainingChart.render({ fullLoss: loss, fullLr: lr, viewXMin: _viewXMin, viewXMax: _viewXMax, smoothingWeight: _smoothingWeight });
+      // For resumed runs, offset X-axis labels so chart shows actual epoch/step numbers
+      const xOff = _chartMode === 'epoch' ? _resumeStartEpoch : _resumeStartStep;
+      TrainingChart.render({ fullLoss: loss, fullLr: lr, viewXMin: _viewXMin, viewXMax: _viewXMax, smoothingWeight: _smoothingWeight, xOffset: xOff });
     }
     // Hide hover dots — Y range may have changed, dots would be stale
     const dotsG = $('monitor-hover-dots');
@@ -1410,6 +1414,13 @@ const Training = (() => {
       const kind = msg.kind || 'step';
 
       if (kind === 'step') {
+        // Capture resume offsets from the very first progress message
+        if (_resumeStartEpoch === 0 && msg.epoch > 1) {
+          _resumeStartEpoch = (msg.epoch - 1) || 0;  // epoch is 1-indexed in progress
+        }
+        if (_lossHistory.length === 0 && _resumeStartEpoch > 0 && msg.step > 0) {
+          _resumeStartStep = _resumeStartStep || msg.step;
+        }
         _step = msg.step || _step;
         _loss = msg.loss ?? _loss;
         _lr = msg.lr ?? _lr;
@@ -1697,6 +1708,7 @@ const Training = (() => {
     _config = config || {};
     _running = true;
     _step = 0; _epoch = 0; _stepInEpoch = 0;
+    _resumeStartEpoch = 0; _resumeStartStep = 0;
     _loss = 0; _bestLoss = Infinity; _bestEpoch = 0; _lr = 0;
     _lossHistory = []; _lrHistory = [];
     _epochLossHistory = []; _epochLrHistory = [];
@@ -1709,6 +1721,14 @@ const Training = (() => {
     _maxEpochs = parseInt(_config.epochs) || 100;
     _stepsPerEpoch = parseInt(_config.steps_per_epoch) || 0;
     _startTime = Date.now(); _epochStartTime = Date.now(); _lastEpochDuration = 0;
+
+    // Detect resume: extract starting epoch from checkpoint path (e.g. .../epoch_100)
+    const resumePath = _config.resume_from || '';
+    const epochMatch = resumePath.match(/epoch_(\d+)/);
+    if (epochMatch) {
+      _resumeStartEpoch = parseInt(epochMatch[1]) || 0;
+      _epoch = _resumeStartEpoch;  // show correct epoch immediately
+    }
 
     // Strip frontend-only keys and zero-means-off fields before sending to backend
     delete _config.steps_per_epoch;

--- a/frontend/js/training.js
+++ b/frontend/js/training.js
@@ -1356,6 +1356,8 @@ const Training = (() => {
 
       if (msg.status === 'done' && !msg.oom) {
         _finalize('complete');
+      } else if (msg.status === 'paused') {
+        _finalize('paused');
       } else if (msg.status === 'failed' || msg.oom) {
         if (!_stopRequested && !_lastFailureMsg) {
           _lastFailureMsg = 'Process exited with code ' + (msg.exit_code ?? '?');
@@ -1530,7 +1532,10 @@ const Training = (() => {
     // Update queue entry status
     const runningEntry = _queue.find(e => e.status === 'running');
     if (runningEntry) {
-      runningEntry.status = finalOutcome === 'complete' ? 'done' : finalOutcome === 'stopped' ? 'stopped' : 'failed';
+      if (finalOutcome === 'complete') runningEntry.status = 'done';
+      else if (finalOutcome === 'paused') runningEntry.status = 'paused';
+      else if (finalOutcome === 'stopped') runningEntry.status = 'stopped';
+      else runningEntry.status = 'failed';
     }
 
     if (typeof AppState !== 'undefined') {
@@ -1542,6 +1547,15 @@ const Training = (() => {
     }
 
     _refreshHistory();
+
+    // Paused: freeze queue — do NOT advance to next pending run
+    if (finalOutcome === 'paused') {
+      if (wasRunning) _showCompletionState('paused');
+      _renderQueue();
+      _syncStartButtons();
+      _stopRequested = false;
+      return;
+    }
 
     // Check if there are more queued runs
     const hasPending = _queue.some(e => e.status === 'pending');
@@ -1592,8 +1606,8 @@ const Training = (() => {
   }
 
   function _runNext() {
-    // Prune finished entries to prevent unbounded growth
-    _queue = _queue.filter(e => e.status === 'pending' || e.status === 'running');
+    // Prune finished entries to prevent unbounded growth (keep paused)
+    _queue = _queue.filter(e => e.status === 'pending' || e.status === 'running' || e.status === 'paused');
     const next = _queue.find(e => e.status === 'pending');
     if (!next) {
       _syncStartButtons();
@@ -1738,9 +1752,11 @@ const Training = (() => {
     // When both crop modes are disabled, chunk_decay_every is irrelevant — strip it too
     if (!_config.chunk_duration && !_config.max_latent_length && _config.chunk_decay_every !== undefined && (Number(_config.chunk_decay_every) === 0 || _config.chunk_decay_every === '0')) delete _config.chunk_decay_every;
 
-    // Reset stop button state from previous run
+    // Reset stop/pause button state from previous run
     const stopBtn = $('btn-stop');
     if (stopBtn) { stopBtn.textContent = 'Stop Training'; stopBtn.disabled = false; }
+    const pauseBtn = $('btn-pause');
+    if (pauseBtn) { pauseBtn.textContent = '\u23F8 Pause'; pauseBtn.disabled = false; }
 
     // Clear chart SVG from previous run
     ['monitor-loss-line', 'monitor-loss-raw', 'monitor-ma-line', 'monitor-lr-line'].forEach(id => {
@@ -1799,6 +1815,8 @@ const Training = (() => {
     _stopRequested = true;
     const stopBtn = $('btn-stop');
     if (stopBtn) { stopBtn.textContent = 'Stopping\u2026'; stopBtn.disabled = true; }
+    const pauseBtn = $('btn-pause');
+    if (pauseBtn) { pauseBtn.disabled = true; }
     _addLog('[info]  Stop requested — waiting for trainer to exit...', 'info');
     try {
       await API.stopTraining();
@@ -1806,16 +1824,60 @@ const Training = (() => {
     // Finalization happens when the subprocess exits and WS sends status
   }
 
+  async function pause() {
+    if (!_running) return;
+    const pauseBtn = $('btn-pause');
+    if (pauseBtn) { pauseBtn.textContent = 'Pausing\u2026'; pauseBtn.disabled = true; }
+    const stopBtn = $('btn-stop');
+    if (stopBtn) { stopBtn.disabled = true; }
+    _addLog('[info]  Pause requested — saving checkpoint at next epoch boundary...', 'info');
+    try {
+      const result = await API.pauseTraining();
+      if (result.error) {
+        _addLog('[warn]  Pause failed: ' + result.error, 'warn');
+        if (pauseBtn) { pauseBtn.textContent = '\u23F8 Pause'; pauseBtn.disabled = false; }
+        if (stopBtn) { stopBtn.disabled = false; }
+      }
+    } catch (err) {
+      _addLog('[warn]  Pause request failed: ' + err.message, 'warn');
+      if (pauseBtn) { pauseBtn.textContent = '\u23F8 Pause'; pauseBtn.disabled = false; }
+      if (stopBtn) { stopBtn.disabled = false; }
+    }
+    // Finalization happens when subprocess saves checkpoint and exits with code 42
+  }
+
+  function resumePaused() {
+    const pausedEntry = _queue.find(e => e.status === 'paused');
+    if (!pausedEntry) {
+      if (typeof showToast === 'function') showToast('No paused run to resume', 'warn');
+      return;
+    }
+    // Point resume_from to the paused checkpoint
+    const outputDir = pausedEntry.config.output_dir || '';
+    pausedEntry.config.resume_from = outputDir + '/paused';
+    pausedEntry.status = 'pending';
+    _renderQueue();
+    _syncStartButtons();
+    if (typeof showToast === 'function') {
+      showToast('Resuming: ' + (pausedEntry.config.run_name || 'training'), 'info');
+    }
+    // Hide completion banner and re-show monitor
+    const completion = $('monitor-completion');
+    if (completion) { completion.style.display = 'none'; }
+    _runNext();
+  }
+
   function _showCompletionState(outcome) {
     const elapsed = (Date.now() - _startTime) / 1000;
     const done = outcome === 'complete';
     const failed = outcome === 'failed';
+    const paused = outcome === 'paused';
     const controls = $('monitor-controls'), completion = $('monitor-completion');
     if (controls) controls.style.display = 'none';
     if (completion) {
-      const c = done ? 'var(--success)' : failed ? 'var(--error)' : 'var(--warning)';
-      const icon = done ? '[ok]' : failed ? '[x]' : '[!]';
-      const label = done ? 'Training Complete' : failed ? 'Training Failed' : 'Training Stopped';
+      const c = done ? 'var(--success)' : failed ? 'var(--error)' : paused ? 'var(--primary)' : 'var(--warning)';
+      const icon = done ? '[ok]' : failed ? '[x]' : paused ? '[||]' : '[!]';
+      const label = done ? 'Training Complete' : failed ? 'Training Failed' : paused ? 'Training Paused' : 'Training Stopped';
       const best = _bestLoss < Infinity ? _bestLoss.toFixed(4) : '--';
       const reason = failed && _lastFailureMsg
         ? '<div class="u-text-error" style="margin-top:var(--space-xs);">Reason: ' + _esc(_lastFailureMsg) + '</div>'
@@ -1830,7 +1892,8 @@ const Training = (() => {
         '<button class="btn btn--primary" id="btn-new-run">New Run</button>' +
         '<button class="btn" id="btn-completed-open-output">Open Output Dir</button>' +
         (done ? '<button class="btn" id="btn-completed-export-comfyui">Export ComfyUI</button>' : '') +
-        (!done ? '<button class="btn btn--success" id="btn-completed-resume">Resume from History</button>' : '') +
+        (paused ? '<button class="btn btn--success" id="btn-completed-resume-paused">\u25B6 Resume Training</button>' : '') +
+        (!done && !paused ? '<button class="btn btn--success" id="btn-completed-resume">Resume from History</button>' : '') +
         '</div></div>';
       completion.style.display = 'block';
       $('btn-new-run')?.addEventListener('click', () => { if (typeof switchMode === 'function') switchMode('ez'); });
@@ -1855,6 +1918,7 @@ const Training = (() => {
           if (btn) { btn.disabled = false; btn.textContent = 'Export ComfyUI'; }
         }
       });
+      $('btn-completed-resume-paused')?.addEventListener('click', () => resumePaused());
       $('btn-completed-resume')?.addEventListener('click', () => {
         if (typeof switchMode === 'function') switchMode('lab');
         _refreshHistory();
@@ -1868,10 +1932,10 @@ const Training = (() => {
     }
     const consoleLine = $('console-line');
     if (consoleLine) {
-      const statusText = done ? 'Training complete' : failed ? 'Training failed' : 'Training stopped';
+      const statusText = done ? 'Training complete' : failed ? 'Training failed' : paused ? 'Training paused — VRAM freed' : 'Training stopped';
       consoleLine.textContent = statusText +
         ' — ' + _epoch + ' epochs, best: ' + (_bestLoss < Infinity ? _bestLoss.toFixed(4) : '--');
-      consoleLine.className = 'console__line console__line--' + (done ? 'epoch' : failed ? 'fail' : 'warn');
+      consoleLine.className = 'console__line console__line--' + (done ? 'epoch' : failed ? 'fail' : paused ? 'info' : 'warn');
     }
   }
 
@@ -2074,8 +2138,9 @@ const Training = (() => {
   function init() {
     $('btn-clear-training-queue')?.addEventListener('click', () => clearQueue());
     $('btn-stop-all')?.addEventListener('click', () => stopAll());
+    $('btn-pause')?.addEventListener('click', () => pause());
   }
 
-  return { init, start, enqueue, stop, stopAll, isRunning, setViewRange, zoomReset, setSmoothing, setChartMode, getChartView, getChartMode, getChartOpts, getDataAtIndex, getSnap, setSnap, collapseExpanded, demoMiniCharts, demoLive, getQueue, queueLength, removeFromQueue, clearQueue };
+  return { init, start, enqueue, stop, stopAll, pause, resumePaused, isRunning, setViewRange, zoomReset, setSmoothing, setChartMode, getChartView, getChartMode, getChartOpts, getDataAtIndex, getSnap, setSnap, collapseExpanded, demoMiniCharts, demoLive, getQueue, queueLength, removeFromQueue, clearQueue };
 
 })();

--- a/frontend/js/training.js
+++ b/frontend/js/training.js
@@ -6,8 +6,57 @@ const Training = (() => {
   let _ws = null, _gpuWs = null;
 
   // ---- Training Queue ---------------------------------------------------
-  let _queue = [];  // { id, config, status: 'pending'|'running'|'done'|'failed'|'stopped' }
+  let _queue = [];  // { id, config, status: 'pending'|'running'|'done'|'failed'|'stopped'|'interrupted' }
   let _queueIdCounter = 0;
+
+  // ---- Persistent queue state (survives browser/server restarts) --------
+  let _saveQueueTimer = null;
+  function _saveQueueState() {
+    // Debounce: batch rapid mutations into a single write
+    if (_saveQueueTimer) clearTimeout(_saveQueueTimer);
+    _saveQueueTimer = setTimeout(() => {
+      _saveQueueTimer = null;
+      const persistable = _queue
+        .filter(e => e.status === 'pending' || e.status === 'paused' || e.status === 'running' || e.status === 'interrupted')
+        .map(e => ({ id: e.id, config: e.config, status: e.status }));
+      API.saveTrainingQueue({ entries: persistable, counter: _queueIdCounter }).catch(err => {
+        console.warn('[Training] Failed to persist queue state:', err);
+      });
+    }, 300);
+  }
+
+  async function _loadQueueState() {
+    try {
+      const saved = await API.loadTrainingQueue();
+      if (!saved || !saved.entries || saved.entries.length === 0) return;
+      // Reclassify 'running' entries as 'interrupted' — the server restarted
+      const restored = saved.entries.map(e => ({
+        ...e,
+        status: e.status === 'running' ? 'interrupted' : e.status,
+      }));
+      // Merge: don't clobber any entries already in memory (live session)
+      const existingIds = new Set(_queue.map(e => e.id));
+      for (const entry of restored) {
+        if (!existingIds.has(entry.id)) {
+          _queue.push(entry);
+        }
+      }
+      _queueIdCounter = Math.max(_queueIdCounter, saved.counter || 0);
+      _renderQueue();
+      _syncStartButtons();
+      const count = restored.length;
+      if (count > 0) {
+        console.log('[Training] Restored', count, 'queue entries from persistent state');
+        const pausedOrInterrupted = restored.filter(e => e.status === 'paused' || e.status === 'interrupted').length;
+        const pending = restored.filter(e => e.status === 'pending').length;
+        if (pausedOrInterrupted > 0 && typeof showToast === 'function') {
+          showToast('Restored queue: ' + pausedOrInterrupted + ' paused, ' + pending + ' pending', 'info');
+        }
+      }
+    } catch (err) {
+      console.warn('[Training] Could not load saved queue state:', err);
+    }
+  }
   let _step = 0, _epoch = 0, _maxEpochs = 100, _stepsPerEpoch = 0, _stepInEpoch = 0;
   let _resumeStartEpoch = 0, _resumeStartStep = 0;  // non-zero when resuming from checkpoint
   let _loss = 0, _bestLoss = Infinity, _bestEpoch = 0, _lr = 0;
@@ -1553,6 +1602,7 @@ const Training = (() => {
       if (wasRunning) _showCompletionState('paused');
       _renderQueue();
       _syncStartButtons();
+      _saveQueueState();
       _stopRequested = false;
       return;
     }
@@ -1581,6 +1631,7 @@ const Training = (() => {
       _renderQueue();
       _syncStartButtons();
     }
+    _saveQueueState();
     _stopRequested = false;
   }
 
@@ -1598,6 +1649,7 @@ const Training = (() => {
     _queue.push(entry);
     _renderQueue();
     _syncStartButtons();
+    _saveQueueState();
     if (!_running) {
       _runNext();
     } else {
@@ -1606,16 +1658,18 @@ const Training = (() => {
   }
 
   function _runNext() {
-    // Prune finished entries to prevent unbounded growth (keep paused)
-    _queue = _queue.filter(e => e.status === 'pending' || e.status === 'running' || e.status === 'paused');
+    // Prune finished entries to prevent unbounded growth (keep paused/interrupted)
+    _queue = _queue.filter(e => e.status === 'pending' || e.status === 'running' || e.status === 'paused' || e.status === 'interrupted');
     const next = _queue.find(e => e.status === 'pending');
     if (!next) {
       _syncStartButtons();
       _renderQueue();
+      _saveQueueState();
       return;
     }
     next.status = 'running';
     _renderQueue();
+    _saveQueueState();
     start(next.config);
   }
 
@@ -1623,12 +1677,14 @@ const Training = (() => {
     _queue = _queue.filter(e => e.id !== id || e.status === 'running');
     _renderQueue();
     _syncStartButtons();
+    _saveQueueState();
   }
 
   function clearQueue() {
     _queue = _queue.filter(e => e.status === 'running' || e.status === 'done' || e.status === 'failed' || e.status === 'stopped');
     _renderQueue();
     _syncStartButtons();
+    _saveQueueState();
     if (typeof showToast === 'function') showToast('Queue cleared', 'info');
   }
 
@@ -1641,7 +1697,8 @@ const Training = (() => {
     if (!panel || !list) return;
     const running = _queue.filter(e => e.status === 'running');
     const pending = _queue.filter(e => e.status === 'pending');
-    if (running.length === 0 && pending.length === 0) { panel.style.display = 'none'; return; }
+    const pausedOrInterrupted = _queue.filter(e => e.status === 'paused' || e.status === 'interrupted');
+    if (running.length === 0 && pending.length === 0 && pausedOrInterrupted.length === 0) { panel.style.display = 'none'; return; }
     panel.style.display = 'block';
     const rows = [];
     running.forEach(entry => {
@@ -1653,6 +1710,20 @@ const Training = (() => {
         (ds ? '<span class="u-text-muted" style="font-size:var(--font-size-xs);">' + ds + '</span>' : '') +
         '<span class="u-text-muted" style="margin-left:auto;font-size:var(--font-size-xs);">running</span>' +
         '</div>');
+    });
+    pausedOrInterrupted.forEach(entry => {
+      const name = _esc(entry.config.run_name || 'training');
+      const ds = _esc(_pathBasename(entry.config.dataset_dir || ''));
+      const label = entry.status === 'interrupted' ? 'interrupted' : 'paused';
+      rows.push('<div style="display:flex;align-items:center;gap:var(--space-sm);padding:3px 0;">' +
+        '<span style="color:var(--warning);">[||]</span> ' +
+        '<span>' + name + '</span>' +
+        (ds ? '<span class="u-text-muted" style="font-size:var(--font-size-xs);">' + ds + '</span>' : '') +
+        '<span style="margin-left:auto;display:flex;gap:var(--space-xs);align-items:center;">' +
+        '<span class="u-text-muted" style="font-size:var(--font-size-xs);">' + label + '</span>' +
+        '<button class="btn btn--sm btn--success" data-queue-resume="' + entry.id + '">\u25B6</button>' +
+        '<button class="btn btn--sm" data-queue-remove="' + entry.id + '">[x]</button>' +
+        '</span></div>');
     });
     pending.forEach(entry => {
       const name = _esc(entry.config.run_name || 'training');
@@ -1667,6 +1738,9 @@ const Training = (() => {
     list.innerHTML = rows.join('');
     list.querySelectorAll('[data-queue-remove]').forEach(btn => {
       btn.addEventListener('click', () => removeFromQueue(btn.dataset.queueRemove));
+    });
+    list.querySelectorAll('[data-queue-resume]').forEach(btn => {
+      btn.addEventListener('click', () => resumePaused());
     });
   }
 
@@ -1847,17 +1921,22 @@ const Training = (() => {
   }
 
   function resumePaused() {
-    const pausedEntry = _queue.find(e => e.status === 'paused');
+    // Find paused or interrupted entry (interrupted = was running when server died)
+    const pausedEntry = _queue.find(e => e.status === 'paused' || e.status === 'interrupted');
     if (!pausedEntry) {
       if (typeof showToast === 'function') showToast('No paused run to resume', 'warn');
       return;
     }
     // Point resume_from to the paused checkpoint
     const outputDir = pausedEntry.config.output_dir || '';
-    pausedEntry.config.resume_from = outputDir + '/paused';
+    if (pausedEntry.status === 'paused') {
+      pausedEntry.config.resume_from = outputDir + '/paused';
+    }
+    // For interrupted runs, resume_from stays as-is (user resumes from last checkpoint)
     pausedEntry.status = 'pending';
     _renderQueue();
     _syncStartButtons();
+    _saveQueueState();
     if (typeof showToast === 'function') {
       showToast('Resuming: ' + (pausedEntry.config.run_name || 'training'), 'info');
     }
@@ -2139,6 +2218,8 @@ const Training = (() => {
     $('btn-clear-training-queue')?.addEventListener('click', () => clearQueue());
     $('btn-stop-all')?.addEventListener('click', () => stopAll());
     $('btn-pause')?.addEventListener('click', () => pause());
+    // Restore persistent queue state (survives browser close / server restart / reboot)
+    _loadQueueState();
   }
 
   return { init, start, enqueue, stop, stopAll, pause, resumePaused, isRunning, setViewRange, zoomReset, setSmoothing, setChartMode, getChartView, getChartMode, getChartOpts, getDataAtIndex, getSnap, setSnap, collapseExpanded, demoMiniCharts, demoLive, getQueue, queueLength, removeFromQueue, clearQueue };

--- a/frontend/js/workspace-config.js
+++ b/frontend/js/workspace-config.js
@@ -229,27 +229,50 @@ const WorkspaceConfig = (() => {
 
   function _autoRunName() {
     if (_runNameManuallyEdited) return;
-    const adapter = $("full-adapter-type")?.value || "lora";
-    const variant = $("full-model-variant")?.value || "turbo";
-    const name = adapter + "_" + variant;
-    const input = $("full-run-name");
-    if (input) {
-      input.value = name;
-      input.dataset.default = name;
-      input.dispatchEvent(new Event("input"));
+    const useDatasetName = $('full-auto-name-dataset')?.checked;
+    const input = $('full-run-name');
+    if (!input) return;
+    if (useDatasetName) {
+      const dsVal = $('full-dataset-dir')?.value || '';
+      const dsName = _baseName(dsVal.replace(/^audio:/, ''));
+      if (dsName) {
+        input.value = dsName;
+        input.dataset.default = dsName;
+        input.dispatchEvent(new Event('input'));
+        return;
+      }
     }
+    const adapter = $('full-adapter-type')?.value || 'lora';
+    const variant = $('full-model-variant')?.value || 'turbo';
+    const name = adapter + '_' + variant;
+    input.value = name;
+    input.dataset.default = name;
+    input.dispatchEvent(new Event('input'));
+  }
+
+  /** Extract the last path segment (folder or file name) from a path. */
+  function _baseName(p) {
+    return String(p || '').replace(/\\/g, '/').replace(/\/+$/, '').split('/').filter(Boolean).pop() || '';
   }
 
   function initRunNameTracking() {
-    const input = $("full-run-name");
+    const input = $('full-run-name');
     if (!input) return;
-    input.addEventListener("input", () => {
+    input.addEventListener('input', () => {
       _runNameManuallyEdited = true;
     });
-    input.addEventListener("focus", () => {
+    input.addEventListener('focus', () => {
       const val = input.value;
       if (val === input.dataset.default) _runNameManuallyEdited = false;
     });
+    // Auto-name from dataset checkbox
+    const autoNameCb = $('full-auto-name-dataset');
+    if (autoNameCb) {
+      autoNameCb.addEventListener('change', () => {
+        _runNameManuallyEdited = false;
+        _autoRunName();
+      });
+    }
   }
 
   /* ---- Ez Review Table (reactive) ---- */
@@ -384,6 +407,7 @@ const WorkspaceConfig = (() => {
 
       _updateConsole("Dataset: " + folder.name + " (" + folder.files + " files)");
     } catch (e) { console.error('[Config] tensor scan failed:', e); }
+    _autoRunName();
   }
 
   /* ---- PP++ Fisher Map Status Check ---- */
@@ -521,5 +545,5 @@ const WorkspaceConfig = (() => {
     initPPPlusStatus();
   }
 
-  return { init, gatherFullConfig, updateEzReview, _autoRunName: _autoRunName };
+  return { init, gatherFullConfig, updateEzReview, _autoRunName: _autoRunName, datasetBaseName: _baseName };
 })();

--- a/frontend/js/workspace-setup.js
+++ b/frontend/js/workspace-setup.js
@@ -451,6 +451,25 @@ const WorkspaceSetup = (() => {
         if (audioOpts.length) options.push(...audioOpts);
         BatchDOM.setOptions(sel, options, current);
       });
+      // Populate batch multi-select checkbox list (Advanced page)
+      const multiList = $("full-dataset-multi-list");
+      if (multiList) {
+        const allSets = [...tensorSets, ...audioSets];
+        if (allSets.length === 0) {
+          multiList.innerHTML = '<div style="color:var(--muted);font-size:var(--font-size-sm);">No datasets found</div>';
+        } else {
+          multiList.innerHTML = allSets.map(f => {
+            const val = f.type === "audio" ? ("audio:" + f.path) : f.path;
+            const icon = f.type === "audio" ? "\u266A" : "\u25A0";
+            const suffix = f.type === "audio" ? " [needs preprocessing]" : (f.pp_map ? " [PP++]" : "");
+            return '<label style="display:flex;align-items:center;gap:var(--space-xs);padding:3px 0;cursor:pointer;font-size:var(--font-size-sm);">' +
+              '<input type="checkbox" class="batch-dataset-cb" data-path="' + _e(val) + '" data-name="' + _e(f.name) + '">' +
+              icon + ' <span>' + _e(f.name) + '</span>' +
+              ' <span style="color:var(--muted);margin-left:auto;white-space:nowrap;">' + _e(f.files) + ' files, ' + _e(f.duration) + suffix + '</span>' +
+              '</label>';
+          }).join('');
+        }
+      }
     } catch (e) { console.error('[Setup] dataset scan failed:', e); }
 
     const gemKey = $("settings-gemini-key")?.value || "";

--- a/frontend/js/workspace.js
+++ b/frontend/js/workspace.js
@@ -552,6 +552,64 @@ document.addEventListener("keydown", (e) => {
       });
     });
 
+    // Batch mode toggle: show/hide multi-select list and Queue Selected button
+    $("full-batch-mode")?.addEventListener("change", () => {
+      const on = $("full-batch-mode").checked;
+      const multi = $("full-dataset-multi");
+      const queueBtn = $("btn-queue-selected");
+      if (multi) multi.style.display = on ? "" : "none";
+      if (queueBtn) queueBtn.style.display = on ? "" : "none";
+    });
+
+    $("btn-batch-select-all")?.addEventListener("click", () => {
+      document.querySelectorAll(".batch-dataset-cb").forEach(cb => { cb.checked = true; });
+    });
+    $("btn-batch-select-none")?.addEventListener("click", () => {
+      document.querySelectorAll(".batch-dataset-cb").forEach(cb => { cb.checked = false; });
+    });
+
+    // Queue Selected: generate one config per checked dataset, enqueue all
+    $("btn-queue-selected")?.addEventListener("click", () => {
+      const checked = [...document.querySelectorAll(".batch-dataset-cb:checked")];
+      if (checked.length === 0) {
+        showToast("No datasets selected — tick at least one", "warn");
+        return;
+      }
+      if (typeof Validation !== 'undefined') {
+        const result = Validation.validateAll();
+        if (result !== true) {
+          showToast(result.slice(0, 3).join(' \u00b7 '), "error");
+          return;
+        }
+      }
+      const _baseName = (typeof WorkspaceConfig !== 'undefined' && WorkspaceConfig.datasetBaseName)
+        ? WorkspaceConfig.datasetBaseName
+        : (p) => String(p || '').replace(/\\/g, '/').replace(/\/+$/, '').split('/').filter(Boolean).pop() || '';
+      let enqueued = 0;
+      checked.forEach(cb => {
+        const dsPath = cb.dataset.path || '';
+        const dsName = cb.dataset.name || _baseName(dsPath.replace(/^audio:/, ''));
+        if (!dsPath) return;
+        const config = typeof WorkspaceConfig !== 'undefined' ? WorkspaceConfig.gatherFullConfig() : {};
+        config.dataset_dir = dsPath;
+        // Always use dataset name for batch runs (+ timestamp for uniqueness)
+        config.run_name = (dsName || "run") + "_" + _timestamp();
+        config.steps_per_epoch = _stepsPerEpoch(config.batch_size, config.grad_accum);
+        config.output_dir = _joinPath(
+          $("settings-adapters-dir")?.value || Defaults.get("settings-adapters-dir") || "trained_adapters",
+          config.adapter_type || "lora",
+          config.run_name
+        );
+        if (_isAudioDataset(dsPath)) {
+          _preprocessThenTrain(config);
+        } else {
+          Training.enqueue(config);
+        }
+        enqueued++;
+      });
+      showToast("Queued " + enqueued + " training run" + (enqueued > 1 ? "s" : ""), "ok");
+    });
+
     // Monitor controls
     $("btn-stop")?.addEventListener("click", () => {
       Training.stop();

--- a/sidestep_engine/core/run_discovery.py
+++ b/sidestep_engine/core/run_discovery.py
@@ -356,19 +356,66 @@ def load_run_config(
     adapters_root: Optional[Path] = None,
     extra_roots: Optional[List[Path]] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Load the training config for a run."""
+    """Load the training config for a run.
+
+    Also merges adapter config (``sidestep_adapter_config.json``) so that
+    adapter-specific fields like ``rank`` are available to callers (e.g. the
+    GUI resume dialog).
+    """
     run_dir = find_run_dir(run_name, adapters_root, extra_roots)
     if run_dir is None:
         return None
 
+    data: Optional[Dict[str, Any]] = None
     for name in ("sidestep_training_config.json", "training_config.json"):
         for tc in (run_dir / "final" / name, run_dir / name):
             if tc.is_file():
                 try:
-                    return json.loads(tc.read_text(encoding="utf-8"))
+                    data = json.loads(tc.read_text(encoding="utf-8"))
+                    break
                 except (json.JSONDecodeError, OSError):
                     pass
-    return None
+        if data is not None:
+            break
+
+    if data is None:
+        return None
+
+    # Merge adapter config so callers get rank/alpha/dropout etc.
+    # The adapter config may live at the run root, in final/, or inside a
+    # checkpoint subdirectory (for in-progress runs that have no final/ yet).
+    ac_candidates = [
+        run_dir / "final" / "sidestep_adapter_config.json",
+        run_dir / "sidestep_adapter_config.json",
+    ]
+    ckpt_root = run_dir / "checkpoints"
+    if ckpt_root.is_dir():
+        # Pick the highest-numbered epoch dir that has the file
+        epoch_dirs = sorted(
+            (d for d in ckpt_root.iterdir()
+             if d.is_dir() and d.name.startswith("epoch_")),
+            key=lambda d: parse_epoch_num(d.name),
+            reverse=True,
+        )
+        for ed in epoch_dirs:
+            ac_candidates.append(ed / "sidestep_adapter_config.json")
+
+    for ac in ac_candidates:
+        if ac.is_file():
+            try:
+                adapter_data = json.loads(ac.read_text(encoding="utf-8"))
+                # Map adapter field 'r' -> 'rank' for GUI convenience
+                if "r" in adapter_data and "rank" not in adapter_data:
+                    adapter_data["rank"] = adapter_data["r"]
+                # Only inject keys that aren't already in the training config
+                for k, v in adapter_data.items():
+                    if k not in data:
+                        data[k] = v
+                break
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    return data
 
 
 def load_run_curve(

--- a/sidestep_engine/core/trainer.py
+++ b/sidestep_engine/core/trainer.py
@@ -1037,6 +1037,63 @@ class FixedLoRATrainer:
                     checkpoint_path=ckpt_dir,
                 )
 
+            # -- Pause detection (file-based IPC from GUI) -----------------
+            _pause_file = output_dir / ".pause_requested"
+            if _pause_file.exists():
+                _paused_dir = str(output_dir / "paused")
+                self.module.model.decoder.eval()
+                _rt_pause = {
+                    "rng_state": capture_rng_state(self.module.device),
+                    "tracker_state": {
+                        "best_loss": best_loss,
+                        "best_epoch": best_epoch,
+                        "patience_counter": patience_counter,
+                        "best_tracking_active": best_tracking_active,
+                        "recent_losses": list(recent_losses),
+                        "cruise_ema": _cruise_ema,
+                    },
+                }
+                if _chunk_sampler is not None:
+                    _rt_pause["chunk_coverage_state"] = _chunk_sampler.state_dict()
+                if _ema is not None:
+                    _rt_pause["ema_state"] = _ema.state_dict()
+                if _adaptive_sampler is not None:
+                    _rt_pause["adaptive_sampler_state"] = _adaptive_sampler.state_dict()
+                if _ema is not None:
+                    _ema.apply()
+                try:
+                    self._save_checkpoint(
+                        optimizer, scheduler, epoch + 1, global_step,
+                        _paused_dir, _rt_pause,
+                    )
+                finally:
+                    if _ema is not None:
+                        _ema.restore()
+                try:
+                    _pause_file.unlink(missing_ok=True)
+                except Exception:
+                    pass
+                _pw.write_event(
+                    kind="paused", step=global_step, loss=avg_epoch_loss,
+                    best_loss=best_loss, best_epoch=best_epoch,
+                )
+                _pw.close()
+                tb.flush()
+                tb.close()
+                yield TrainingUpdate(
+                    step=global_step, loss=avg_epoch_loss,
+                    msg=(
+                        f"[OK] Training paused at epoch {epoch + 1}, step {global_step}. "
+                        f"Checkpoint saved to {_paused_dir}"
+                    ),
+                    kind="complete",
+                )
+                logger.info(
+                    "[Side-Step] Training paused at epoch %d, step %d -> %s",
+                    epoch + 1, global_step, _paused_dir,
+                )
+                sys.exit(42)
+
             # Clear CUDA cache AFTER checkpoint save so serialization
             # temporaries are also freed.
             if torch.cuda.is_available():

--- a/sidestep_engine/core/trainer_loop.py
+++ b/sidestep_engine/core/trainer_loop.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import math
+import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Tuple
@@ -730,6 +731,63 @@ def run_basic_training_loop(
                 kind="checkpoint", epoch=epoch + 1, max_epochs=cfg.max_epochs,
                 checkpoint_path=ckpt_dir,
             )
+
+        # -- Pause detection (file-based IPC from GUI) ---------------------
+        _pause_file = output_dir / ".pause_requested"
+        if _pause_file.exists():
+            _paused_dir = str(output_dir / "paused")
+            module.model.decoder.eval()
+            _rt_pause = {
+                "rng_state": capture_rng_state(module.device),
+                "tracker_state": {
+                    "best_loss": best_loss,
+                    "best_epoch": best_epoch,
+                    "patience_counter": patience_counter,
+                    "best_tracking_active": best_tracking_active,
+                    "recent_losses": list(recent_losses),
+                    "cruise_ema": _cruise_ema,
+                },
+            }
+            if _chunk_sampler is not None:
+                _rt_pause["chunk_coverage_state"] = _chunk_sampler.state_dict()
+            if _ema is not None:
+                _rt_pause["ema_state"] = _ema.state_dict()
+            if _adaptive_sampler is not None:
+                _rt_pause["adaptive_sampler_state"] = _adaptive_sampler.state_dict()
+            if _ema is not None:
+                _ema.apply()
+            try:
+                save_checkpoint(
+                    trainer, optimizer, scheduler, epoch + 1, global_step,
+                    _paused_dir, _rt_pause,
+                )
+            finally:
+                if _ema is not None:
+                    _ema.restore()
+            try:
+                _pause_file.unlink(missing_ok=True)
+            except Exception:
+                pass
+            _pw.write_event(
+                kind="paused", step=global_step, loss=avg_epoch_loss,
+                best_loss=best_loss, best_epoch=best_epoch,
+            )
+            _pw.close()
+            tb.flush()
+            tb.close()
+            yield TrainingUpdate(
+                step=global_step, loss=avg_epoch_loss,
+                msg=(
+                    f"[OK] Training paused at epoch {epoch + 1}, step {global_step}. "
+                    f"Checkpoint saved to {_paused_dir}"
+                ),
+                kind="complete",
+            )
+            logger.info(
+                "[Side-Step] Training paused at epoch %d, step %d -> %s",
+                epoch + 1, global_step, _paused_dir,
+            )
+            sys.exit(42)
 
         # Clear CUDA cache AFTER checkpoint save so serialization
         # temporaries are also freed.

--- a/sidestep_engine/gui/server.py
+++ b/sidestep_engine/gui/server.py
@@ -717,6 +717,32 @@ def create_app(token: str | None = None, port: int = 8770) -> FastAPI:
         result = tm.pause_training()
         return JSONResponse(result)
 
+    # -- Persistent training queue state -----------------------------------
+
+    _QUEUE_STATE_FILE = _PROJECT_ROOT / ".sidestep" / "training_queue.json"
+
+    @app.get("/api/train/queue")
+    async def get_training_queue():
+        """Return the persisted training queue state (survives restarts)."""
+        try:
+            if _QUEUE_STATE_FILE.exists():
+                return JSONResponse(json.loads(_QUEUE_STATE_FILE.read_text("utf-8")))
+        except Exception:
+            logger.warning("[train/queue] Failed to read %s", _QUEUE_STATE_FILE)
+        return JSONResponse({"entries": [], "counter": 0})
+
+    @app.post("/api/train/queue")
+    async def save_training_queue(request: Request):
+        """Persist the current training queue state to disk."""
+        try:
+            body = await request.json()
+            _QUEUE_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+            _QUEUE_STATE_FILE.write_text(json.dumps(body, indent=2), "utf-8")
+        except Exception as exc:
+            logger.warning("[train/queue] Failed to write %s: %s", _QUEUE_STATE_FILE, exc)
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+        return JSONResponse({"ok": True})
+
     # ======================================================================
     # Task control (preprocess, PP++, captions)
     # ======================================================================

--- a/sidestep_engine/gui/server.py
+++ b/sidestep_engine/gui/server.py
@@ -712,6 +712,11 @@ def create_app(token: str | None = None, port: int = 8770) -> FastAPI:
         result = tm.stop_training()
         return JSONResponse(result)
 
+    @app.post("/api/train/pause")
+    async def pause_training():
+        result = tm.pause_training()
+        return JSONResponse(result)
+
     # ======================================================================
     # Task control (preprocess, PP++, captions)
     # ======================================================================

--- a/sidestep_engine/gui/task_manager.py
+++ b/sidestep_engine/gui/task_manager.py
@@ -289,6 +289,39 @@ class TaskManager:
         threading.Thread(target=_escalate, daemon=True).start()
         return {"ok": True, "task_id": task.task_id}
 
+    def pause_training(self) -> Dict[str, Any]:
+        """Request a graceful pause by writing a signal file to the output dir.
+
+        The training subprocess checks for ``.pause_requested`` at each epoch
+        boundary.  When found it saves a full checkpoint to ``paused/``, deletes
+        the signal file, and exits with code 42.
+        """
+        with self._lock:
+            task = self._training_task
+        if not task or task.status != "running":
+            return {"error": "No training running"}
+        # Read the config that was used to launch this run
+        config_path = task.config_file
+        if not config_path or not os.path.exists(config_path):
+            return {"error": "Could not determine output directory"}
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                config = json.load(f)
+        except Exception as exc:
+            return {"error": f"Could not read config: {exc}"}
+        output_dir = str(config.get("output_dir", "")).strip()
+        if not output_dir:
+            return {"error": "No output_dir in training config"}
+        # Resolve relative to project root (same CWD as subprocess)
+        pause_file = (_PROJECT_ROOT / output_dir / ".pause_requested").resolve()
+        try:
+            pause_file.parent.mkdir(parents=True, exist_ok=True)
+            pause_file.write_text("pause", encoding="utf-8")
+        except Exception as exc:
+            return {"error": f"Could not write pause signal: {exc}"}
+        logger.info("[TaskManager] Pause requested -> %s", pause_file)
+        return {"ok": True, "task_id": task.task_id}
+
     async def get_training_update(self) -> Optional[Dict[str, Any]]:
         """Non-blocking fetch of the next training update."""
         try:
@@ -341,7 +374,12 @@ class TaskManager:
             pass  # pipe closed
         finally:
             rc = task.process.wait()
-            task.status = "done" if rc == 0 else "failed"
+            if rc == 0:
+                task.status = "done"
+            elif rc == 42:
+                task.status = "paused"
+            else:
+                task.status = "failed"
 
             reason = task.failure_reason
             if not reason and rc != 0:


### PR DESCRIPTION
# Training control: pause/resume, persistent queue, resume-display fixes

**Pause/resume.** Pause (GUI button → file-based handshake) captures a complete resumable checkpoint — adapter, optimizer, scheduler, RNG state, EMA shadow, chunk-coverage and adaptive-sampler state — then exits cleanly; resume restarts from it through the normal resume path.

**Persistent training queue.** The multi-dataset training queue is persisted server-side, so it survives browser close, server restart, and reboot. Run names auto-derive from the dataset; batch-queueing several datasets is one action.

**Resume display fixes.**
- The GUI resume dialog now shows real rank/alpha: `load_run_config` merges `sidestep_adapter_config.json` from `final/`, the run root, or the highest `epoch_N` checkpoint (mapping PEFT `r` → `rank`).
- Training chart gains `xOffset` so a resumed run's X-axis continues from the original epoch instead of restarting at 0; stats row uses session-relative step timing.

Note: an earlier version of this work also patched adapter weight loading on resume; that half is superseded by the #46 resume strategy ladder and is not included here — this PR composes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
