### PR TITLE
Dynamic genre conditioning + conditioning monitor

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1755,6 +1755,13 @@
               </div>
             </div>
 
+            <div class="panel" id="monitor-conditioning-panel" style="margin-bottom: var(--space-md); display: none;">
+              <div class="panel__title">Conditioning</div>
+              <div style="font-size: var(--font-size-sm);" id="monitor-conditioning">
+                <div style="color: var(--muted); padding: 3px 0;">Waiting for data...</div>
+              </div>
+            </div>
+
             <div class="panel">
               <div class="panel__title">Config</div>
               <div style="font-size: var(--font-size-sm);" id="monitor-config-summary">

--- a/frontend/js/training.js
+++ b/frontend/js/training.js
@@ -1264,6 +1264,29 @@ const Training = (() => {
     return { totalLen: len, startIdx: _viewXMin ?? 0, endIdx: _viewXMax ?? len };
   }
 
+  function _renderConditioningPanel(info) {
+    const panel = $('monitor-conditioning-panel');
+    const container = $('monitor-conditioning');
+    if (!panel || !container) return;
+    panel.style.display = '';
+    container.innerHTML = '';
+    for (const item of info) {
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;justify-content:space-between;padding:2px 0;';
+      const nameSpan = document.createElement('span');
+      nameSpan.style.cssText = 'color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:60%;';
+      nameSpan.textContent = item.name || '?';
+      nameSpan.title = item.name || '?';
+      const typeSpan = document.createElement('span');
+      const isGenre = item.type === 'genre';
+      typeSpan.style.cssText = 'font-weight:bold;color:' + (isGenre ? 'var(--accent)' : 'var(--secondary)') + ';';
+      typeSpan.textContent = item.type || 'caption';
+      row.appendChild(nameSpan);
+      row.appendChild(typeSpan);
+      container.appendChild(row);
+    }
+  }
+
   function _addLog(msg, kind) {
     const log = $('monitor-log');
     if (!log) return;
@@ -1441,6 +1464,11 @@ const Training = (() => {
         if (msg.target_loss_ema != null) {
           if (!_tbScalars['target_loss_ema']) _tbScalars['target_loss_ema'] = [];
           _tbScalars['target_loss_ema'].push({ step: _step, value: msg.target_loss_ema, wall_time: wt });
+        }
+
+        // Conditioning info: per-sample genre/caption selection
+        if (msg.conditioning_info && Array.isArray(msg.conditioning_info)) {
+          _renderConditioningPanel(msg.conditioning_info);
         }
       }
 
@@ -1738,6 +1766,10 @@ const Training = (() => {
     _el('monitor-run-name', _config.run_name || 'training');
     _el('monitor-output-dir', 'Output: ' + (_config.output_dir || ''));
     const log = $('monitor-log'); if (log) log.innerHTML = '';
+    const condPanel = $('monitor-conditioning-panel');
+    if (condPanel) { condPanel.style.display = 'none'; }
+    const condContent = $('monitor-conditioning');
+    if (condContent) { condContent.innerHTML = '<div style="color:var(--muted);padding:3px 0;">Waiting for data...</div>'; }
     _fillConfigSummary();
     _addLog('[info]  Starting training...', 'info');
     document.querySelector('[data-mode="monitor"]')?.classList.add('training');

--- a/sidestep_engine/core/configs.py
+++ b/sidestep_engine/core/configs.py
@@ -446,6 +446,12 @@ class TrainingConfigV2(TrainingConfig):
     times per epoch.  1 = no repetition (default).  Higher values effectively
     multiply dataset size without modifying ``.pt`` files."""
 
+    genre_ratio: int = -1
+    """Percentage (0-100) of training steps that use genre conditioning
+    instead of caption.  ``-1`` = auto-detect from ``preprocess_meta.json``
+    (default).  ``0`` = always use caption.  Both variants are stored in
+    the ``.pt`` files; this controls the per-step random selection."""
+
     max_steps: int = 0
     """Maximum optimizer steps.  0 = disabled (use max_epochs only).
     When > 0, training stops at this step count regardless of epoch."""

--- a/sidestep_engine/core/trainer.py
+++ b/sidestep_engine/core/trainer.py
@@ -202,6 +202,7 @@ class FixedLoRATrainer:
                 max_latent_length=getattr(cfg, "max_latent_length", None),
                 chunk_decay_every=getattr(cfg, "chunk_decay_every", 10),
                 dataset_repeats=getattr(cfg, "dataset_repeats", 1),
+                genre_ratio=getattr(cfg, "genre_ratio", -1),
             )
             data_module.setup("fit")
 

--- a/sidestep_engine/core/trainer.py
+++ b/sidestep_engine/core/trainer.py
@@ -661,6 +661,7 @@ class FixedLoRATrainer:
             epoch_loss = 0.0
             num_updates = 0
             epoch_start = time.time()
+            _accum_cond_info: list = []
 
             for _batch_idx, batch in enumerate(train_loader):
                 # Stop signal
@@ -675,6 +676,12 @@ class FixedLoRATrainer:
                     yield TrainingUpdate(global_step, _stop_loss, "[INFO] Training stopped by user", kind="complete")
                     tb.close()
                     return
+
+                # Extract non-tensor keys before training_step
+                _batch_cond = batch.pop("conditioning_info", None)
+                batch.pop("metadata", None)
+                if _batch_cond:
+                    _accum_cond_info.extend(_batch_cond)
 
                 loss = self.module.training_step(batch)
 
@@ -767,10 +774,17 @@ class FixedLoRATrainer:
                             )
 
                     _lr = optimizer.param_groups[0]["lr"]
+                    _pw_extra = {}
+                    if _target_loss > 0 and global_step >= _CRUISE_MIN_STEPS:
+                        _pw_extra["target_loss_scale"] = _scale
+                        _pw_extra["target_loss_ema"] = _cruise_ema
+                    if _accum_cond_info:
+                        _pw_extra["conditioning_info"] = _accum_cond_info
                     _pw.maybe_write(step=global_step, epoch=epoch + 1,
                                     max_epochs=cfg.max_epochs, loss=avg_loss, lr=_lr,
                                     best_loss=best_loss, best_epoch=best_epoch,
-                                    steps_per_epoch=steps_per_epoch)
+                                    steps_per_epoch=steps_per_epoch, **_pw_extra)
+                    _accum_cond_info = []
                     if global_step % cfg.log_every == 0:
                         tb.log_loss(avg_loss, global_step)
                         tb.log_lr(_lr, global_step)

--- a/sidestep_engine/core/trainer_loop.py
+++ b/sidestep_engine/core/trainer_loop.py
@@ -417,6 +417,8 @@ def run_basic_training_loop(
         num_updates = 0
         epoch_start = time.time()
 
+        _accum_cond_info: list = []
+
         for batch in train_loader:
             if training_state and training_state.get("should_stop", False):
                 _stop_loss = (
@@ -429,6 +431,12 @@ def run_basic_training_loop(
                 yield TrainingUpdate(global_step, _stop_loss, "[INFO] Training stopped", kind="complete")
                 tb.close()
                 return
+
+            # Extract non-tensor keys before training_step
+            _batch_cond = batch.pop("conditioning_info", None)
+            batch.pop("metadata", None)
+            if _batch_cond:
+                _accum_cond_info.extend(_batch_cond)
 
             loss = module.training_step(batch)
 
@@ -519,6 +527,8 @@ def run_basic_training_loop(
                 if _target_loss > 0 and global_step >= _CRUISE_MIN_STEPS:
                     _pw_extra["target_loss_scale"] = _scale
                     _pw_extra["target_loss_ema"] = _cruise_ema
+                if _accum_cond_info:
+                    _pw_extra["conditioning_info"] = _accum_cond_info
                 _pw.maybe_write(step=global_step, epoch=epoch + 1,
                                 max_epochs=cfg.max_epochs, loss=avg_loss, lr=_lr,
                                 best_loss=best_loss, best_epoch=best_epoch,
@@ -527,6 +537,7 @@ def run_basic_training_loop(
                 num_updates += 1
                 accumulated_loss = 0.0
                 accumulation_step = 0
+                _accum_cond_info = []
 
                 # Step-level best-model tracking
                 if _step_best_every > 0 and cfg.save_best and best_tracking_active:

--- a/sidestep_engine/data/preprocess.py
+++ b/sidestep_engine/data/preprocess.py
@@ -31,7 +31,6 @@ from sidestep_engine.data.preprocess_discovery import (
     load_dataset_metadata as _load_dataset_metadata,
     load_sample_metadata as _load_sample_metadata,
     safe_output_stem as _safe_output_stem,
-    select_genre_indices as _select_genre_indices,
 )
 from sidestep_engine.data.preprocess_prompt import (
     build_simple_prompt as _build_simple_prompt,
@@ -332,13 +331,6 @@ def _pass1_light(
 
     # Dataset-level prompt settings from ACE-Step's metadata block
     tag_position = ds_meta.get("tag_position", "prepend")
-    genre_ratio = ds_meta.get("genre_ratio", 0)
-    genre_indices = _select_genre_indices(total, genre_ratio)
-    if genre_indices:
-        logger.info(
-            "[Side-Step] genre_ratio=%d%% -- %d/%d samples will use genre as prompt",
-            genre_ratio, len(genre_indices), total,
-        )
     if tag_position != "prepend":
         logger.info("[Side-Step] tag_position=%s (from dataset metadata)", tag_position)
 
@@ -395,15 +387,14 @@ def _pass1_light(
                 caption = sm.get("caption", af.stem)
                 lyrics = sm.get("lyrics", "[Instrumental]")
 
-                # Build text prompt using dataset-level tag_position and genre_ratio
-                use_genre = i in genre_indices
-                text_prompt = _build_simple_prompt(sm, tag_position=tag_position, use_genre=use_genre)
+                # Build CAPTION text prompt (always encoded)
+                caption_prompt = _build_simple_prompt(sm, tag_position=tag_position, use_genre=False)
 
                 with torch.no_grad():
-                    text_hs, text_mask = encode_text(text_enc, tokenizer, text_prompt, device, dtype)
+                    text_hs, text_mask = encode_text(text_enc, tokenizer, caption_prompt, device, dtype)
                     lyric_hs, lyric_mask = encode_lyrics(text_enc, tokenizer, lyrics, device, dtype)
 
-                # Validate text encoder outputs
+                # Validate caption text encoder outputs
                 _bad_tensor = None
                 for _tname, _tens in [("text_hs", text_hs), ("lyric_hs", lyric_hs)]:
                     if torch.isnan(_tens).any() or torch.isinf(_tens).any():
@@ -419,9 +410,31 @@ def _pass1_light(
                     del lyric_hs, lyric_mask
                     continue
 
+                # Build GENRE text prompt (only when sample has genre text)
+                genre_text = sm.get("genre", "")
+                has_genre = bool(genre_text and genre_text.strip())
+                genre_text_hs = None
+                genre_text_mask = None
+                if has_genre:
+                    genre_prompt = _build_simple_prompt(sm, tag_position=tag_position, use_genre=True)
+                    with torch.no_grad():
+                        genre_text_hs, genre_text_mask = encode_text(
+                            text_enc, tokenizer, genre_prompt, device, dtype,
+                        )
+                    # Validate genre text encoder output
+                    if torch.isnan(genre_text_hs).any() or torch.isinf(genre_text_hs).any():
+                        logger.warning(
+                            "[Side-Step] Pass 1: genre text NaN/Inf for %s -- skipping genre variant",
+                            af.name,
+                        )
+                        del genre_text_hs, genre_text_mask
+                        genre_text_hs = None
+                        genre_text_mask = None
+                        has_genre = False
+
                 # 4. Save intermediate
                 tmp_path = out_path / f"{_stem}.tmp.pt"
-                torch.save({
+                save_dict = {
                     "target_latents": target_latents.squeeze(0).cpu(),
                     "attention_mask": attention_mask.squeeze(0).cpu(),
                     "text_hidden_states": text_hs.cpu(),
@@ -445,11 +458,18 @@ def _pass1_light(
                         "prompt_override": sm.get("prompt_override"),
                         "repeat": 1,  # Global dataset_repeats replaces per-sample repeat
                     },
-                }, tmp_path)
+                }
+                # Store genre text variant alongside caption variant
+                if has_genre and genre_text_hs is not None:
+                    save_dict["genre_text_hidden_states"] = genre_text_hs.cpu()
+                    save_dict["genre_text_attention_mask"] = genre_text_mask.cpu()
+                torch.save(save_dict, tmp_path)
 
                 # Free GPU tensors from this iteration before the next one
                 del target_latents, attention_mask, text_hs, text_mask
-                del lyric_hs, lyric_mask
+                del lyric_hs, lyric_mask, save_dict
+                if genre_text_hs is not None:
+                    del genre_text_hs, genre_text_mask
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
                 elif hasattr(torch, 'mps') and torch.mps.is_available():
@@ -458,7 +478,8 @@ def _pass1_light(
                     torch.xpu.empty_cache()
 
                 intermediates.append(tmp_path)
-                logger.debug("[Side-Step] Pass 1 OK: %s", af.name)
+                _genre_tag = " [+genre]" if has_genre else ""
+                logger.debug("[Side-Step] Pass 1 OK: %s%s", af.name, _genre_tag)
                 if progress_callback:
                     progress_callback(i + 1, total, f"[Pass 1] OK: {af.name}")
 
@@ -535,8 +556,7 @@ def _pass2_heavy(
                 silence_latent = data["silence_latent"].to(model_device, dtype=model_dtype)
                 latent_length = data["latent_length"]
 
-                # DIT encoder pass (adapter-agnostic: same tensors for
-                # LoRA and LoKR -- only the adapter injection differs).
+                # --- Caption variant (always encoded) --------------------------
                 encoder_hs, encoder_mask = run_encoder(
                     model,
                     text_hidden_states=text_hs,
@@ -547,8 +567,29 @@ def _pass2_heavy(
                     dtype=model_dtype,
                 )
 
-                # Free encoder inputs immediately after use
-                del text_hs, text_mask, lyric_hs, lyric_mask
+                # Free caption text inputs (lyrics are reused for genre variant)
+                del text_hs, text_mask
+
+                # --- Genre variant (only when intermediate has genre text) ------
+                has_genre = "genre_text_hidden_states" in data
+                genre_encoder_hs = None
+                genre_encoder_mask = None
+                if has_genre:
+                    genre_text_hs = data["genre_text_hidden_states"].to(model_device, dtype=model_dtype)
+                    genre_text_mask = data["genre_text_attention_mask"].to(model_device, dtype=model_dtype)
+                    genre_encoder_hs, genre_encoder_mask = run_encoder(
+                        model,
+                        text_hidden_states=genre_text_hs,
+                        text_attention_mask=genre_text_mask,
+                        lyric_hidden_states=lyric_hs,
+                        lyric_attention_mask=lyric_mask,
+                        device=str(model_device),
+                        dtype=model_dtype,
+                    )
+                    del genre_text_hs, genre_text_mask
+
+                # Free shared lyric tensors
+                del lyric_hs, lyric_mask
 
                 # Build context latents (silence-based, standard text2music)
                 if silence_latent.dim() == 2:
@@ -575,25 +616,45 @@ def _pass2_heavy(
                         _bad_tensor, tmp_path.stem,
                     )
                     del encoder_hs, encoder_mask, context_latents, data
+                    if genre_encoder_hs is not None:
+                        del genre_encoder_hs, genre_encoder_mask
                     continue
+
+                # Validate genre variant if present (non-fatal: drop genre only)
+                if genre_encoder_hs is not None:
+                    if torch.isnan(genre_encoder_hs).any() or torch.isinf(genre_encoder_hs).any():
+                        logger.warning(
+                            "[Side-Step] Pass 2: genre encoder NaN/Inf for %s -- dropping genre variant",
+                            tmp_path.stem,
+                        )
+                        del genre_encoder_hs, genre_encoder_mask
+                        genre_encoder_hs = None
+                        genre_encoder_mask = None
+                        has_genre = False
 
                 # Atomic write: save to staging path then os.replace to final
                 base_name = tmp_path.name.replace(".tmp.pt", ".pt")
                 final_path = out_path / base_name
                 staging_path = out_path / (base_name + ".__writing__")
                 meta = data["metadata"]
-                torch.save({
+                save_dict = {
                     "target_latents": data["target_latents"],
                     "attention_mask": data["attention_mask"],
                     "encoder_hidden_states": encoder_hs.squeeze(0).cpu(),
                     "encoder_attention_mask": encoder_mask.squeeze(0).cpu(),
                     "context_latents": context_latents.squeeze(0).cpu(),
                     "metadata": meta,
-                }, staging_path)
+                }
+                if has_genre and genre_encoder_hs is not None:
+                    save_dict["encoder_hidden_states_genre"] = genre_encoder_hs.squeeze(0).cpu()
+                    save_dict["encoder_attention_mask_genre"] = genre_encoder_mask.squeeze(0).cpu()
+                torch.save(save_dict, staging_path)
                 os.replace(staging_path, final_path)
 
                 # Free all GPU tensors and the loaded data dict before next iter
-                del encoder_hs, encoder_mask, context_latents, data
+                del encoder_hs, encoder_mask, context_latents, data, save_dict
+                if genre_encoder_hs is not None:
+                    del genre_encoder_hs, genre_encoder_mask
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
                 elif hasattr(torch, 'mps') and torch.mps.is_available():
@@ -605,7 +666,8 @@ def _pass2_heavy(
                 tmp_path.unlink(missing_ok=True)
 
                 processed += 1
-                logger.debug("[Side-Step] Pass 2 OK: %s", tmp_path.stem)
+                _genre_tag = " [+genre]" if has_genre else ""
+                logger.debug("[Side-Step] Pass 2 OK: %s%s", tmp_path.stem, _genre_tag)
                 if progress_callback:
                     progress_callback(i + 1, total, f"[Pass 2] OK: {tmp_path.stem}")
 

--- a/sidestep_engine/vendor/data_module.py
+++ b/sidestep_engine/vendor/data_module.py
@@ -412,6 +412,8 @@ class PreprocessedTensorDataset(Dataset):
                 attention_mask = attention_mask[start:end]
                 context_latents = context_latents[start:end]
 
+        conditioning_type = "genre" if use_genre else "caption"
+
         return {
             "target_latents": target_latents,           # [T', 64]
             "attention_mask": attention_mask,             # [T']
@@ -419,6 +421,7 @@ class PreprocessedTensorDataset(Dataset):
             "encoder_attention_mask": encoder_attention_mask,  # [L]
             "context_latents": context_latents,          # [T', 65]
             "metadata": metadata,
+            "conditioning_type": conditioning_type,
         }
 
 
@@ -474,6 +477,14 @@ def collate_preprocessed_batch(batch: List[Dict]) -> Dict[str, torch.Tensor]:
             eam = torch.cat([eam, pad], dim=0)
         encoder_attention_masks.append(eam)
 
+    # Gather per-sample conditioning info for monitor feedback
+    conditioning_info = []
+    for s in batch:
+        meta = s.get("metadata", {})
+        fname = meta.get("filename", "?")
+        ctype = s.get("conditioning_type", "caption")
+        conditioning_info.append({"name": fname, "type": ctype})
+
     return {
         "target_latents": torch.stack(target_latents),  # [B, T, 64]
         "attention_mask": torch.stack(attention_masks),  # [B, T]
@@ -481,6 +492,7 @@ def collate_preprocessed_batch(batch: List[Dict]) -> Dict[str, torch.Tensor]:
         "encoder_attention_mask": torch.stack(encoder_attention_masks),  # [B, L]
         "context_latents": torch.stack(context_latents),  # [B, T, 65]
         "metadata": [s["metadata"] for s in batch],
+        "conditioning_info": conditioning_info,
     }
 
 

--- a/sidestep_engine/vendor/data_module.py
+++ b/sidestep_engine/vendor/data_module.py
@@ -110,6 +110,7 @@ class PreprocessedTensorDataset(Dataset):
         dataset_repeats: int = 1,
         verify_checksums: bool = False,
         cache_in_ram: Optional[bool] = None,
+        genre_ratio: int = -1,
     ):
         """Initialize from a directory of preprocessed .pt files.
 
@@ -132,11 +133,22 @@ class PreprocessedTensorDataset(Dataset):
             cache_in_ram: If True, cache all tensors in RAM for faster
                 I/O. If None (default), auto-enable when total dataset
                 size is below 4 GB.
+            genre_ratio: Percentage (0-100) of training steps that use
+                the genre conditioning variant instead of caption.
+                ``-1`` = auto-detect from ``preprocess_meta.json``.
+                ``0``  = always caption (default behaviour).
         """
         self.tensor_dir = tensor_dir
         self.chunk_duration = chunk_duration
         self.max_latent_length = max_latent_length
         self._chunk_decay_every = chunk_decay_every
+
+        # Auto-detect genre_ratio from preprocess_meta.json when -1
+        if genre_ratio < 0:
+            genre_ratio = self._read_genre_ratio(tensor_dir)
+        self._genre_ratio = max(0, min(100, genre_ratio))
+        if self._genre_ratio > 0:
+            logger.info("genre_ratio=%d%% -- genre variant selected per step", self._genre_ratio)
         self.sample_paths = []
         self.manifest_path = str(Path(tensor_dir) / "manifest.json")
         self.manifest_error: Optional[str] = None
@@ -255,7 +267,20 @@ class PreprocessedTensorDataset(Dataset):
         repeat_info = ""
         if len(self.valid_paths) != self._unique_count:
             repeat_info = f" ({self._unique_count} unique, {len(self.valid_paths)} with repeats)"
-        logger.info(f"PreprocessedTensorDataset: {len(self.valid_paths)} samples{repeat_info} from {tensor_dir}{chunk_info}")
+        genre_info = f", genre_ratio={self._genre_ratio}%" if self._genre_ratio > 0 else ""
+        logger.info(f"PreprocessedTensorDataset: {len(self.valid_paths)} samples{repeat_info} from {tensor_dir}{chunk_info}{genre_info}")
+
+    @staticmethod
+    def _read_genre_ratio(tensor_dir: str) -> int:
+        """Read genre_ratio from preprocess_meta.json (0 if absent)."""
+        meta_path = Path(tensor_dir) / "preprocess_meta.json"
+        if not meta_path.is_file():
+            return 0
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            return int(meta.get("genre_ratio", 0))
+        except Exception:
+            return 0
 
     def _verify_checksums(self, tensor_dir: str) -> None:
         """Verify MD5 checksums from preprocess_meta.json."""
@@ -335,8 +360,21 @@ class PreprocessedTensorDataset(Dataset):
         target_latents = data["target_latents"]      # [T, 64]
         attention_mask = data["attention_mask"]        # [T]
         context_latents = data["context_latents"]      # [T, 65]
-        encoder_hidden_states = data["encoder_hidden_states"]  # [L, D]
-        encoder_attention_mask = data["encoder_attention_mask"]  # [L]
+
+        # Dynamic genre/caption selection: pick genre variant with
+        # probability genre_ratio/100 when available in the .pt file.
+        use_genre = (
+            self._genre_ratio > 0
+            and "encoder_hidden_states_genre" in data
+            and random.randint(1, 100) <= self._genre_ratio
+        )
+        if use_genre:
+            encoder_hidden_states = data["encoder_hidden_states_genre"]  # [L, D]
+            encoder_attention_mask = data["encoder_attention_mask_genre"]  # [L]
+        else:
+            encoder_hidden_states = data["encoder_hidden_states"]  # [L, D]
+            encoder_attention_mask = data["encoder_attention_mask"]  # [L]
+
         metadata = data.get("metadata", {})
         del data
 
@@ -467,6 +505,7 @@ class PreprocessedDataModule(LightningDataModule if LIGHTNING_AVAILABLE else obj
         max_latent_length: Optional[int] = None,
         chunk_decay_every: int = 10,
         dataset_repeats: int = 1,
+        genre_ratio: int = -1,
     ):
         """Initialize the data module.
 
@@ -480,6 +519,8 @@ class PreprocessedDataModule(LightningDataModule if LIGHTNING_AVAILABLE else obj
             max_latent_length: Random crop length in latent frames (None = disabled)
             chunk_decay_every: Epoch interval for coverage histogram decay.
             dataset_repeats: Global dataset repetition multiplier (1 = none).
+            genre_ratio: Percentage (0-100) of steps using genre variant.
+                ``-1`` = auto-detect from preprocess_meta.json.
         """
         if LIGHTNING_AVAILABLE:
             super().__init__()
@@ -496,6 +537,7 @@ class PreprocessedDataModule(LightningDataModule if LIGHTNING_AVAILABLE else obj
         self.max_latent_length = max_latent_length
         self.chunk_decay_every = chunk_decay_every
         self.dataset_repeats = dataset_repeats
+        self.genre_ratio = genre_ratio
 
         self.train_dataset = None
         self.val_dataset = None
@@ -509,6 +551,7 @@ class PreprocessedDataModule(LightningDataModule if LIGHTNING_AVAILABLE else obj
                 max_latent_length=self.max_latent_length,
                 chunk_decay_every=self.chunk_decay_every,
                 dataset_repeats=self.dataset_repeats,
+                genre_ratio=self.genre_ratio,
             )
 
             if self.val_split > 0 and len(full_dataset) > 1:


### PR DESCRIPTION
# Dynamic genre conditioning + conditioning monitor

**Part 1 of a 5-part training-core series** (#67 → #68 → #69 → #70 → #71). Merging in order keeps every diff small — each later PR currently shows its predecessors' commits until they merge.

**Dynamic genre conditioning.** Preprocessing now encodes BOTH the caption and the genre-tag text variant into each `.pt` (new optional keys — old tensors keep loading, `genre_ratio` semantics unchanged for them). Training then selects caption vs genre *per sample per step* according to `genre_ratio` (auto-detected from `preprocess_meta.json` when unset), replacing the old static per-sample choice frozen at preprocess time. This removes the systematic bias where a sample was forever caption-only or genre-only for the whole run. Requires re-preprocessing to benefit; degrades gracefully without it.

**Conditioning monitor.** `conditioning_type` flows from the dataset through collate into ProgressWriter events, and the training monitor shows live caption-vs-genre usage per batch. Also ports the target-loss scale/EMA telemetry to the Fabric trainer path (previously basic-loop only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
